### PR TITLE
feat: github actions CD 스크립트 작성

### DIFF
--- a/.github/workflows/cd-be.yml
+++ b/.github/workflows/cd-be.yml
@@ -1,0 +1,21 @@
+name: Deploy BE to Server
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - dev
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Run SSH
+        uses: appleboy/ssh-action@v1.1.0
+        with:
+          host: ${{ secrets.HOST }}
+          username: ${{ secrets.USERNAME }}
+          password: ${{ secrets.PASSWORD }}
+          port: ${{ secrets.PORT }}
+          script: sh /root/boostcamp/deploy.sh


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #84

## 소요 시간

4시간

## 개발한 사항

- Github Actions 백엔드 CD(지속적 배포) 스크립트 작성
- 서버 SSH 접속을 위해 Secrets에 HOST, USERNAME, PASSWORD, PORT 추가
- 서버에 배포 쉘 스크립트 파일 작성

## 고민했던 사항

- https://velog.io/@jungsangu/기본-브랜치가-아닌-곳에서-Github-Actions-Workflow-파일-작성하기
- https://foamy-rose-f4f.notion.site/Github-Actions-CD-0ca679cc301c43daad703663ee4ea814?pvs=74
