### PR TITLE
<BE> 공부방 관련 서비스를 분리한다.

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -4,9 +4,10 @@ import { AppService } from './app.service';
 import { SignalingServerModule } from './signaling-server/signaling-server.module';
 import { WinstonModule } from 'nest-winston';
 import { winstonConfig } from '../winston.config';
+import { StudyRoomModule } from './study-room/study-room.module';
 
 @Module({
-  imports: [SignalingServerModule, WinstonModule.forRoot(winstonConfig)],
+  imports: [SignalingServerModule, WinstonModule.forRoot(winstonConfig), StudyRoomModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/server/src/signaling-server/signaling-server.gateway.spec.ts
+++ b/server/src/signaling-server/signaling-server.gateway.spec.ts
@@ -4,6 +4,7 @@ import { StudyRoomsService } from '../study-room/study-room.service';
 import { MockStudyRoomRepository } from '../study-room/mock.repository';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
+import { Socket } from 'socket.io';
 
 describe('SignalingServerGateway', () => {
   let gateway: SignalingServerGateway;
@@ -38,13 +39,13 @@ describe('SignalingServerGateway', () => {
   });
 
   it('사용자가 접속하면 logger.info가 호출되어야 합니다.', () => {
-    const clientMock = { id: 'user1', emit: jest.fn() } as any;
+    const clientMock = { id: 'user1', emit: jest.fn() } as unknown as Socket;
     gateway.handleConnection(clientMock);
     expect(logger.info).toHaveBeenCalledWith('user1 접속!!!');
   });
 
   it('사용자가 접속 해제하면 logger.info가 호출되어야 합니다.', () => {
-    const clientMock = { id: 'user1' } as any;
+    const clientMock = { id: 'user1' } as unknown as Socket;
     gateway.handleDisconnect(clientMock);
     expect(logger.info).toHaveBeenCalledWith('user1 접속해제!!!');
   });

--- a/server/src/signaling-server/signaling-server.gateway.spec.ts
+++ b/server/src/signaling-server/signaling-server.gateway.spec.ts
@@ -1,18 +1,51 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SignalingServerGateway } from './signaling-server.gateway';
+import { StudyRoomsService } from '../study-room/study-room.service';
+import { MockStudyRoomRepository } from '../study-room/mock.repository';
+import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
+import { Logger } from 'winston';
 
 describe('SignalingServerGateway', () => {
   let gateway: SignalingServerGateway;
+  let logger: Logger;
+  let studyRoomsService: StudyRoomsService;
 
   beforeEach(async () => {
+    // Mock Logger 생성
+    const mockLogger = {
+      info: jest.fn(),
+      error: jest.fn(),
+      warn: jest.fn(),
+    };
+
+    const mockRepository = new MockStudyRoomRepository();
+    studyRoomsService = new StudyRoomsService(mockRepository);
+
     const module: TestingModule = await Test.createTestingModule({
-      providers: [SignalingServerGateway],
+      providers: [
+        SignalingServerGateway,
+        { provide: WINSTON_MODULE_PROVIDER, useValue: mockLogger },
+        { provide: StudyRoomsService, useValue: studyRoomsService },
+      ],
     }).compile();
 
     gateway = module.get<SignalingServerGateway>(SignalingServerGateway);
+    logger = module.get<Logger>(WINSTON_MODULE_PROVIDER);
   });
 
-  it('should be defined', () => {
+  it('SignalingServerGateway가 정의되어야 합니다.', () => {
     expect(gateway).toBeDefined();
+  });
+
+  it('사용자가 접속하면 logger.info가 호출되어야 합니다.', () => {
+    const clientMock = { id: 'user1', emit: jest.fn() } as any;
+    gateway.handleConnection(clientMock);
+    expect(logger.info).toHaveBeenCalledWith('user1 접속!!!');
+  });
+
+  it('사용자가 접속 해제하면 logger.info가 호출되어야 합니다.', () => {
+    const clientMock = { id: 'user1' } as any;
+    gateway.handleDisconnect(clientMock);
+    expect(logger.info).toHaveBeenCalledWith('user1 접속해제!!!');
   });
 });

--- a/server/src/signaling-server/signaling-server.gateway.ts
+++ b/server/src/signaling-server/signaling-server.gateway.ts
@@ -11,31 +11,31 @@ import { Socket, Server } from 'socket.io';
 import { Inject } from '@nestjs/common';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
+import { StudyRoomsService } from '../study-room/study-room.service';
 
 @WebSocketGateway({ cors: { origin: '*' } })
 export class SignalingServerGateway implements OnGatewayConnection, OnGatewayDisconnect {
   constructor(
     @Inject(WINSTON_MODULE_PROVIDER)
     private readonly logger: Logger,
-  ) {}
-
-  // 방에 들어있는 사용자의 소켓 정보
-  users = [];
+    private readonly studyRoomsService: StudyRoomsService,
+  ) { }
 
   @WebSocketServer()
   server: Server;
 
-  // 1. 신규 참가자가 접속을 요청한다. 그리고 방에 있는
-  // 기존참가자들 소켓 정보를 반환한다.
+  // 1. 신규 참가자가 접속을 요청한다. 그리고 방에 있는 기존 참가자들 소켓 정보를 반환한다.
   handleConnection(client: Socket) {
     this.logger.info(`${client.id} 접속!!!`);
-    client.emit('offerRequest', JSON.stringify({ users: this.users }));
-    this.users.push(client.id);
+    const defaultRoom = '1';
+    this.studyRoomsService.addUserToRoom(defaultRoom, client.id);
+    const users = this.studyRoomsService.getRoomUsers(defaultRoom).filter((id) => id !== client.id);
+    client.emit('offerRequest', JSON.stringify({ users }));
   }
 
   handleDisconnect(client: Socket) {
     this.logger.info(`${client.id} 접속해제!!!`);
-    this.users = this.users.filter((user) => user !== client.id);
+    this.studyRoomsService.leaveAllRooms(client.id);
   }
 
   // 2. 신규 참가자가 기존 참가자들에게 offer를 보낸다.
@@ -45,7 +45,7 @@ export class SignalingServerGateway implements OnGatewayConnection, OnGatewayDis
     @MessageBody('offer') offer: RTCSessionDescriptionInit,
     @MessageBody('oldId') oldId: string,
   ) {
-    this.logger.info(`new user: ${client.id} sends an offer to old user: ${oldId} `);
+    this.logger.info(`new user: ${client.id} sends an offer to old user: ${oldId}`);
     this.server.to(oldId).emit('answerRequest', JSON.stringify({ newId: client.id, offer }));
   }
 
@@ -56,7 +56,7 @@ export class SignalingServerGateway implements OnGatewayConnection, OnGatewayDis
     @MessageBody('answer') answer: RTCSessionDescriptionInit,
     @MessageBody('newId') newId: string,
   ) {
-    this.logger.info(`old user: ${client.id} sends an answer to new user: ${newId} `);
+    this.logger.info(`old user: ${client.id} sends an answer to new user: ${newId}`);
     this.server.to(newId).emit('completeConnection', JSON.stringify({ oldId: client.id, answer }));
   }
 
@@ -66,9 +66,7 @@ export class SignalingServerGateway implements OnGatewayConnection, OnGatewayDis
     @MessageBody('targetId') targetId: string,
     @MessageBody('iceCandidate') candidate: RTCIceCandidateInit,
   ) {
-    this.logger.info(`user: ${client.id} send ice candidate to user: ${targetId}`);
-    this.server
-      .to(targetId)
-      .emit('setIceCandidate', JSON.stringify({ senderId: client.id, iceCandidate: candidate }));
+    this.logger.info(`user: ${client.id} sends ICE candidate to user: ${targetId}`);
+    this.server.to(targetId).emit('setIceCandidate', JSON.stringify({ senderId: client.id, iceCandidate: candidate }));
   }
 }

--- a/server/src/signaling-server/signaling-server.gateway.ts
+++ b/server/src/signaling-server/signaling-server.gateway.ts
@@ -19,7 +19,7 @@ export class SignalingServerGateway implements OnGatewayConnection, OnGatewayDis
     @Inject(WINSTON_MODULE_PROVIDER)
     private readonly logger: Logger,
     private readonly studyRoomsService: StudyRoomsService,
-  ) { }
+  ) {}
 
   @WebSocketServer()
   server: Server;
@@ -67,6 +67,8 @@ export class SignalingServerGateway implements OnGatewayConnection, OnGatewayDis
     @MessageBody('iceCandidate') candidate: RTCIceCandidateInit,
   ) {
     this.logger.info(`user: ${client.id} sends ICE candidate to user: ${targetId}`);
-    this.server.to(targetId).emit('setIceCandidate', JSON.stringify({ senderId: client.id, iceCandidate: candidate }));
+    this.server
+      .to(targetId)
+      .emit('setIceCandidate', JSON.stringify({ senderId: client.id, iceCandidate: candidate }));
   }
 }

--- a/server/src/signaling-server/signaling-server.module.ts
+++ b/server/src/signaling-server/signaling-server.module.ts
@@ -6,4 +6,4 @@ import { StudyRoomModule } from 'src/study-room/study-room.module';
   imports: [StudyRoomModule],
   providers: [SignalingServerGateway],
 })
-export class SignalingServerModule { }
+export class SignalingServerModule {}

--- a/server/src/signaling-server/signaling-server.module.ts
+++ b/server/src/signaling-server/signaling-server.module.ts
@@ -1,7 +1,9 @@
 import { Module } from '@nestjs/common';
 import { SignalingServerGateway } from './signaling-server.gateway';
+import { StudyRoomModule } from 'src/study-room/study-room.module';
 
 @Module({
+  imports: [StudyRoomModule],
   providers: [SignalingServerGateway],
 })
-export class SignalingServerModule {}
+export class SignalingServerModule { }

--- a/server/src/study-room/mock.repository.spec.ts
+++ b/server/src/study-room/mock.repository.spec.ts
@@ -1,43 +1,43 @@
-import { MockStudyRoomRepository } from "./mock.repository";
+import { MockStudyRoomRepository } from './mock.repository';
 
 describe('MockStudyRoomRepository', () => {
-    let repository: MockStudyRoomRepository;
+  let repository: MockStudyRoomRepository;
 
-    beforeEach(() => {
-        repository = new MockStudyRoomRepository();
-    });
+  beforeEach(() => {
+    repository = new MockStudyRoomRepository();
+  });
 
-    describe('사용자가 특정 방에 연결되었을 때', () => {
-        it('사용자가 방에 추가된다', () => {
-            repository.addUserToRoom('room1', 'user1');
-            const users = repository.getRoomUsers('room1');
-            expect(users).toContain('user1');
-        });
+  describe('사용자가 특정 방에 연결되었을 때', () => {
+    it('사용자가 방에 추가된다', () => {
+      repository.addUserToRoom('room1', 'user1');
+      const users = repository.getRoomUsers('room1');
+      expect(users).toContain('user1');
     });
+  });
 
-    describe('사용자가 방에서 나갔을 때', () => {
-        it('사용자가 방에서 제거된다', () => {
-            repository.addUserToRoom('room1', 'user1');
-            repository.removeUserFromRoom('room1', 'user1');
-            const users = repository.getRoomUsers('room1');
-            expect(users).not.toContain('user1');
-        });
+  describe('사용자가 방에서 나갔을 때', () => {
+    it('사용자가 방에서 제거된다', () => {
+      repository.addUserToRoom('room1', 'user1');
+      repository.removeUserFromRoom('room1', 'user1');
+      const users = repository.getRoomUsers('room1');
+      expect(users).not.toContain('user1');
     });
+  });
 
-    describe('존재하지 않는 방에 접근했을 때', () => {
-        it('빈 배열이 반환된다', () => {
-            const users = repository.getRoomUsers('nonExistentRoom');
-            expect(users).toEqual([]);
-        });
+  describe('존재하지 않는 방에 접근했을 때', () => {
+    it('빈 배열이 반환된다', () => {
+      const users = repository.getRoomUsers('nonExistentRoom');
+      expect(users).toEqual([]);
     });
+  });
 
-    describe('사용자가 모든 방에서 나갔을 때', () => {
-        it('모든 방에서 해당 사용자가 제거된다', () => {
-            repository.addUserToRoom('room1', 'user1');
-            repository.addUserToRoom('room2', 'user1');
-            repository.leaveAllRooms('user1');
-            expect(repository.getRoomUsers('room1')).not.toContain('user1');
-            expect(repository.getRoomUsers('room2')).not.toContain('user1');
-        });
+  describe('사용자가 모든 방에서 나갔을 때', () => {
+    it('모든 방에서 해당 사용자가 제거된다', () => {
+      repository.addUserToRoom('room1', 'user1');
+      repository.addUserToRoom('room2', 'user1');
+      repository.leaveAllRooms('user1');
+      expect(repository.getRoomUsers('room1')).not.toContain('user1');
+      expect(repository.getRoomUsers('room2')).not.toContain('user1');
     });
+  });
 });

--- a/server/src/study-room/mock.repository.spec.ts
+++ b/server/src/study-room/mock.repository.spec.ts
@@ -1,0 +1,43 @@
+import { MockStudyRoomRepository } from "./mock.repository";
+
+describe('MockStudyRoomRepository', () => {
+    let repository: MockStudyRoomRepository;
+
+    beforeEach(() => {
+        repository = new MockStudyRoomRepository();
+    });
+
+    describe('사용자가 특정 방에 연결되었을 때', () => {
+        it('사용자가 방에 추가된다', () => {
+            repository.addUserToRoom('room1', 'user1');
+            const users = repository.getRoomUsers('room1');
+            expect(users).toContain('user1');
+        });
+    });
+
+    describe('사용자가 방에서 나갔을 때', () => {
+        it('사용자가 방에서 제거된다', () => {
+            repository.addUserToRoom('room1', 'user1');
+            repository.removeUserFromRoom('room1', 'user1');
+            const users = repository.getRoomUsers('room1');
+            expect(users).not.toContain('user1');
+        });
+    });
+
+    describe('존재하지 않는 방에 접근했을 때', () => {
+        it('빈 배열이 반환된다', () => {
+            const users = repository.getRoomUsers('nonExistentRoom');
+            expect(users).toEqual([]);
+        });
+    });
+
+    describe('사용자가 모든 방에서 나갔을 때', () => {
+        it('모든 방에서 해당 사용자가 제거된다', () => {
+            repository.addUserToRoom('room1', 'user1');
+            repository.addUserToRoom('room2', 'user1');
+            repository.leaveAllRooms('user1');
+            expect(repository.getRoomUsers('room1')).not.toContain('user1');
+            expect(repository.getRoomUsers('room2')).not.toContain('user1');
+        });
+    });
+});

--- a/server/src/study-room/mock.repository.ts
+++ b/server/src/study-room/mock.repository.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { StudyRoom } from './study-room.entity';
+
+@Injectable()
+export class MockStudyRoomRepository {
+    private rooms: Map<string, StudyRoom> = new Map();
+
+    createRoom(roomId: string): StudyRoom {
+        const newRoom = new StudyRoom(roomId);
+        this.rooms.set(roomId, newRoom);
+        return newRoom;
+    }
+
+    findRoom(roomId: string): StudyRoom | undefined {
+        return this.rooms.get(roomId);
+    }
+
+    addUserToRoom(roomId: string, clientId: string) {
+        const room = this.rooms.get(roomId);
+        if (!room) {
+            this.createRoom(roomId);
+        }
+        this.rooms.get(roomId)?.users.push(clientId);
+    }
+
+    removeUserFromRoom(roomId: string, clientId: string) {
+        const room = this.rooms.get(roomId);
+        if (room) {
+            room.users = room.users.filter((id) => id !== clientId);
+        }
+    }
+
+    getRoomUsers(roomId: string): string[] {
+        return this.rooms.get(roomId)?.users || [];
+    }
+
+    leaveAllRooms(clientId: string) {
+        this.rooms.forEach((room) => {
+            room.users = room.users.filter((id) => id !== clientId);
+        });
+    }
+}

--- a/server/src/study-room/mock.repository.ts
+++ b/server/src/study-room/mock.repository.ts
@@ -3,40 +3,40 @@ import { StudyRoom } from './study-room.entity';
 
 @Injectable()
 export class MockStudyRoomRepository {
-    private rooms: Map<string, StudyRoom> = new Map();
+  private rooms: Map<string, StudyRoom> = new Map();
 
-    createRoom(roomId: string): StudyRoom {
-        const newRoom = new StudyRoom(roomId);
-        this.rooms.set(roomId, newRoom);
-        return newRoom;
-    }
+  createRoom(roomId: string): StudyRoom {
+    const newRoom = new StudyRoom(roomId);
+    this.rooms.set(roomId, newRoom);
+    return newRoom;
+  }
 
-    findRoom(roomId: string): StudyRoom | undefined {
-        return this.rooms.get(roomId);
-    }
+  findRoom(roomId: string): StudyRoom | undefined {
+    return this.rooms.get(roomId);
+  }
 
-    addUserToRoom(roomId: string, clientId: string) {
-        const room = this.rooms.get(roomId);
-        if (!room) {
-            this.createRoom(roomId);
-        }
-        this.rooms.get(roomId)?.users.push(clientId);
+  addUserToRoom(roomId: string, clientId: string) {
+    const room = this.rooms.get(roomId);
+    if (!room) {
+      this.createRoom(roomId);
     }
+    this.rooms.get(roomId)?.users.push(clientId);
+  }
 
-    removeUserFromRoom(roomId: string, clientId: string) {
-        const room = this.rooms.get(roomId);
-        if (room) {
-            room.users = room.users.filter((id) => id !== clientId);
-        }
+  removeUserFromRoom(roomId: string, clientId: string) {
+    const room = this.rooms.get(roomId);
+    if (room) {
+      room.users = room.users.filter((id) => id !== clientId);
     }
+  }
 
-    getRoomUsers(roomId: string): string[] {
-        return this.rooms.get(roomId)?.users || [];
-    }
+  getRoomUsers(roomId: string): string[] {
+    return this.rooms.get(roomId)?.users || [];
+  }
 
-    leaveAllRooms(clientId: string) {
-        this.rooms.forEach((room) => {
-            room.users = room.users.filter((id) => id !== clientId);
-        });
-    }
+  leaveAllRooms(clientId: string) {
+    this.rooms.forEach((room) => {
+      room.users = room.users.filter((id) => id !== clientId);
+    });
+  }
 }

--- a/server/src/study-room/study-room.entity.ts
+++ b/server/src/study-room/study-room.entity.ts
@@ -1,9 +1,9 @@
 export class StudyRoom {
-    roomId: string;
-    users: string[];
+  roomId: string;
+  users: string[];
 
-    constructor(roomId: string) {
-        this.roomId = roomId;
-        this.users = [];
-    }
+  constructor(roomId: string) {
+    this.roomId = roomId;
+    this.users = [];
+  }
 }

--- a/server/src/study-room/study-room.entity.ts
+++ b/server/src/study-room/study-room.entity.ts
@@ -1,0 +1,9 @@
+export class StudyRoom {
+    roomId: string;
+    users: string[];
+
+    constructor(roomId: string) {
+        this.roomId = roomId;
+        this.users = [];
+    }
+}

--- a/server/src/study-room/study-room.module.ts
+++ b/server/src/study-room/study-room.module.ts
@@ -1,8 +1,9 @@
 import { Module } from '@nestjs/common';
 import { StudyRoomsService } from './study-room.service';
+import { MockStudyRoomRepository } from './mock.repository';
 
 @Module({
-    providers: [StudyRoomsService],
+    providers: [StudyRoomsService, MockStudyRoomRepository],
     exports: [StudyRoomsService],
 })
 export class StudyRoomModule { }

--- a/server/src/study-room/study-room.module.ts
+++ b/server/src/study-room/study-room.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { StudyRoomsService } from './study-room.service';
+
+@Module({
+    providers: [StudyRoomsService],
+    exports: [StudyRoomsService],
+})
+export class StudyRoomModule { }

--- a/server/src/study-room/study-room.module.ts
+++ b/server/src/study-room/study-room.module.ts
@@ -3,7 +3,7 @@ import { StudyRoomsService } from './study-room.service';
 import { MockStudyRoomRepository } from './mock.repository';
 
 @Module({
-    providers: [StudyRoomsService, MockStudyRoomRepository],
-    exports: [StudyRoomsService],
+  providers: [StudyRoomsService, MockStudyRoomRepository],
+  exports: [StudyRoomsService],
 })
-export class StudyRoomModule { }
+export class StudyRoomModule {}

--- a/server/src/study-room/study-room.repository.spec.ts
+++ b/server/src/study-room/study-room.repository.spec.ts
@@ -1,6 +1,6 @@
 import { MockStudyRoomRepository } from './mock.repository';
 
-describe('MockStudyRoomRepository', () => {
+describe('Study Room 레포지토리 테스트', () => {
   let repository: MockStudyRoomRepository;
 
   beforeEach(() => {

--- a/server/src/study-room/study-room.service.spec.ts
+++ b/server/src/study-room/study-room.service.spec.ts
@@ -1,0 +1,46 @@
+import { StudyRoomsService } from "./study-room.service";
+import { MockStudyRoomRepository } from "./mock.repository";
+
+describe('StudyRoomsService', () => {
+    let service: StudyRoomsService;
+    let mockRepository: MockStudyRoomRepository;
+
+    beforeEach(() => {
+        mockRepository = new MockStudyRoomRepository();
+        service = new StudyRoomsService(mockRepository);
+    });
+
+    describe('사용자가 방에 접속했을 때', () => {
+        it('사용자가 방에 추가된다', () => {
+            service.addUserToRoom('room1', 'user1');
+            const users = service.getRoomUsers('room1');
+            expect(users).toContain('user1');
+        });
+    });
+
+    describe('사용자가 방에서 나갔을 때', () => {
+        it('사용자가 방에서 제거된다', () => {
+            service.addUserToRoom('room1', 'user1');
+            service.removeUserFromRoom('room1', 'user1');
+            const users = service.getRoomUsers('room1');
+            expect(users).not.toContain('user1');
+        });
+    });
+
+    describe('존재하지 않는 방에 접근했을 때', () => {
+        it('빈 배열이 반환된다', () => {
+            const users = service.getRoomUsers('nonExistentRoom');
+            expect(users).toEqual([]);
+        });
+    });
+
+    describe('사용자가 모든 방에서 나갔을 때', () => {
+        it('모든 방에서 해당 사용자가 제거된다', () => {
+            service.addUserToRoom('room1', 'user1');
+            service.addUserToRoom('room2', 'user1');
+            service.leaveAllRooms('user1');
+            expect(service.getRoomUsers('room1')).not.toContain('user1');
+            expect(service.getRoomUsers('room2')).not.toContain('user1');
+        });
+    });
+});

--- a/server/src/study-room/study-room.service.spec.ts
+++ b/server/src/study-room/study-room.service.spec.ts
@@ -1,46 +1,46 @@
-import { StudyRoomsService } from "./study-room.service";
-import { MockStudyRoomRepository } from "./mock.repository";
+import { StudyRoomsService } from './study-room.service';
+import { MockStudyRoomRepository } from './mock.repository';
 
 describe('StudyRoomsService', () => {
-    let service: StudyRoomsService;
-    let mockRepository: MockStudyRoomRepository;
+  let service: StudyRoomsService;
+  let mockRepository: MockStudyRoomRepository;
 
-    beforeEach(() => {
-        mockRepository = new MockStudyRoomRepository();
-        service = new StudyRoomsService(mockRepository);
-    });
+  beforeEach(() => {
+    mockRepository = new MockStudyRoomRepository();
+    service = new StudyRoomsService(mockRepository);
+  });
 
-    describe('사용자가 방에 접속했을 때', () => {
-        it('사용자가 방에 추가된다', () => {
-            service.addUserToRoom('room1', 'user1');
-            const users = service.getRoomUsers('room1');
-            expect(users).toContain('user1');
-        });
+  describe('사용자가 방에 접속했을 때', () => {
+    it('사용자가 방에 추가된다', () => {
+      service.addUserToRoom('room1', 'user1');
+      const users = service.getRoomUsers('room1');
+      expect(users).toContain('user1');
     });
+  });
 
-    describe('사용자가 방에서 나갔을 때', () => {
-        it('사용자가 방에서 제거된다', () => {
-            service.addUserToRoom('room1', 'user1');
-            service.removeUserFromRoom('room1', 'user1');
-            const users = service.getRoomUsers('room1');
-            expect(users).not.toContain('user1');
-        });
+  describe('사용자가 방에서 나갔을 때', () => {
+    it('사용자가 방에서 제거된다', () => {
+      service.addUserToRoom('room1', 'user1');
+      service.removeUserFromRoom('room1', 'user1');
+      const users = service.getRoomUsers('room1');
+      expect(users).not.toContain('user1');
     });
+  });
 
-    describe('존재하지 않는 방에 접근했을 때', () => {
-        it('빈 배열이 반환된다', () => {
-            const users = service.getRoomUsers('nonExistentRoom');
-            expect(users).toEqual([]);
-        });
+  describe('존재하지 않는 방에 접근했을 때', () => {
+    it('빈 배열이 반환된다', () => {
+      const users = service.getRoomUsers('nonExistentRoom');
+      expect(users).toEqual([]);
     });
+  });
 
-    describe('사용자가 모든 방에서 나갔을 때', () => {
-        it('모든 방에서 해당 사용자가 제거된다', () => {
-            service.addUserToRoom('room1', 'user1');
-            service.addUserToRoom('room2', 'user1');
-            service.leaveAllRooms('user1');
-            expect(service.getRoomUsers('room1')).not.toContain('user1');
-            expect(service.getRoomUsers('room2')).not.toContain('user1');
-        });
+  describe('사용자가 모든 방에서 나갔을 때', () => {
+    it('모든 방에서 해당 사용자가 제거된다', () => {
+      service.addUserToRoom('room1', 'user1');
+      service.addUserToRoom('room2', 'user1');
+      service.leaveAllRooms('user1');
+      expect(service.getRoomUsers('room1')).not.toContain('user1');
+      expect(service.getRoomUsers('room2')).not.toContain('user1');
     });
+  });
 });

--- a/server/src/study-room/study-room.service.ts
+++ b/server/src/study-room/study-room.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class StudyRoomsService {
+    private rooms: { [key: string]: string[] } = {};
+
+    addUserToRoom(room: string, clientId: string) {
+        if (!this.rooms[room]) {
+            this.rooms[room] = [];
+        }
+        this.rooms[room].push(clientId);
+    }
+
+    removeUserFromRoom(room: string, clientId: string) {
+        this.rooms[room] = this.rooms[room]?.filter((id) => id !== clientId);
+    }
+
+    getRoomUsers(room: string): string[] {
+        return this.rooms[room] || [];
+    }
+
+    leaveAllRooms(clientId: string) {
+        Object.keys(this.rooms).forEach((room) => {
+            this.rooms[room] = this.rooms[room]?.filter((id) => id !== clientId);
+        });
+    }
+}

--- a/server/src/study-room/study-room.service.ts
+++ b/server/src/study-room/study-room.service.ts
@@ -3,21 +3,21 @@ import { MockStudyRoomRepository } from './mock.repository';
 
 @Injectable()
 export class StudyRoomsService {
-    constructor(private readonly roomRepository: MockStudyRoomRepository) { }
+  constructor(private readonly roomRepository: MockStudyRoomRepository) {}
 
-    addUserToRoom(room: string, clientId: string) {
-        this.roomRepository.addUserToRoom(room, clientId);
-    }
+  addUserToRoom(room: string, clientId: string) {
+    this.roomRepository.addUserToRoom(room, clientId);
+  }
 
-    removeUserFromRoom(room: string, clientId: string) {
-        this.roomRepository.removeUserFromRoom(room, clientId);
-    }
+  removeUserFromRoom(room: string, clientId: string) {
+    this.roomRepository.removeUserFromRoom(room, clientId);
+  }
 
-    getRoomUsers(room: string): string[] {
-        return this.roomRepository.getRoomUsers(room);
-    }
+  getRoomUsers(room: string): string[] {
+    return this.roomRepository.getRoomUsers(room);
+  }
 
-    leaveAllRooms(clientId: string) {
-        this.roomRepository.leaveAllRooms(clientId);
-    }
+  leaveAllRooms(clientId: string) {
+    this.roomRepository.leaveAllRooms(clientId);
+  }
 }

--- a/server/src/study-room/study-room.service.ts
+++ b/server/src/study-room/study-room.service.ts
@@ -1,27 +1,23 @@
 import { Injectable } from '@nestjs/common';
+import { MockStudyRoomRepository } from './mock.repository';
 
 @Injectable()
 export class StudyRoomsService {
-    private rooms: { [key: string]: string[] } = {};
+    constructor(private readonly roomRepository: MockStudyRoomRepository) { }
 
     addUserToRoom(room: string, clientId: string) {
-        if (!this.rooms[room]) {
-            this.rooms[room] = [];
-        }
-        this.rooms[room].push(clientId);
+        this.roomRepository.addUserToRoom(room, clientId);
     }
 
     removeUserFromRoom(room: string, clientId: string) {
-        this.rooms[room] = this.rooms[room]?.filter((id) => id !== clientId);
+        this.roomRepository.removeUserFromRoom(room, clientId);
     }
 
     getRoomUsers(room: string): string[] {
-        return this.rooms[room] || [];
+        return this.roomRepository.getRoomUsers(room);
     }
 
     leaveAllRooms(clientId: string) {
-        Object.keys(this.rooms).forEach((room) => {
-            this.rooms[room] = this.rooms[room]?.filter((id) => id !== clientId);
-        });
+        this.roomRepository.leaveAllRooms(clientId);
     }
 }

--- a/server/src/study-room/study-room.service.ts
+++ b/server/src/study-room/study-room.service.ts
@@ -1,22 +1,60 @@
 import { Injectable } from '@nestjs/common';
 import { MockStudyRoomRepository } from './mock.repository';
+import { StudyRoom } from './study-room.entity';
 
 @Injectable()
 export class StudyRoomsService {
   constructor(private readonly roomRepository: MockStudyRoomRepository) {}
 
-  addUserToRoom(room: string, clientId: string) {
-    this.roomRepository.addUserToRoom(room, clientId);
+  /**
+   * 새로운 방을 생성합니다.
+   * @param roomId 방 ID
+   * @returns 생성된 방
+   */
+  createRoom(roomId: string): StudyRoom {
+    return this.roomRepository.createRoom(roomId);
   }
 
-  removeUserFromRoom(room: string, clientId: string) {
-    this.roomRepository.removeUserFromRoom(room, clientId);
+  /**
+   * 방을 조회합니다.
+   * @param roomId 방 ID
+   * @returns 방 객체 또는 undefined
+   */
+  findRoom(roomId: string): StudyRoom | undefined {
+    return this.roomRepository.findRoom(roomId);
   }
 
-  getRoomUsers(room: string): string[] {
-    return this.roomRepository.getRoomUsers(room);
+  /**
+   * 사용자를 방에 추가합니다.
+   * @param roomId 방 ID
+   * @param clientId 클라이언트 ID
+   */
+  addUserToRoom(roomId: string, clientId: string) {
+    this.roomRepository.addUserToRoom(roomId, clientId);
   }
 
+  /**
+   * 사용자를 방에서 제거합니다.
+   * @param roomId 방 ID
+   * @param clientId 클라이언트 ID
+   */
+  removeUserFromRoom(roomId: string, clientId: string) {
+    this.roomRepository.removeUserFromRoom(roomId, clientId);
+  }
+
+  /**
+   * 특정 방의 모든 사용자를 조회합니다.
+   * @param roomId 방 ID
+   * @returns 방에 있는 사용자의 목록
+   */
+  getRoomUsers(roomId: string): string[] {
+    return this.roomRepository.getRoomUsers(roomId);
+  }
+
+  /**
+   * 특정 사용자를 모든 방에서 제거합니다.
+   * @param clientId 클라이언트 ID
+   */
   leaveAllRooms(clientId: string) {
     this.roomRepository.leaveAllRooms(clientId);
   }


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #91 #92 

## 소요 시간
3시간

## 개발한 사항
- 공부방 관련된 서비스를 `study-room`이라는 모듈로 분리하여 사용
  ![image](https://github.com/user-attachments/assets/4bc03819-4d9a-4021-b5f0-b3fb2b493717)


- signalling-server 테스트 코드에 logger 의존성을 주입하지 않아서 발생하는 현상 수정
```ts
const module: TestingModule = await Test.createTestingModule({
  providers: [
    SignalingServerGateway,
    { provide: WINSTON_MODULE_PROVIDER, useValue: mockLogger },
     { provide: StudyRoomsService, useValue: studyRoomsService },
  ],
}).compile();
```

## 고민했던 사항
- api server에 대한 디렉토리 구조를 어떻게 할 지 고민
```scss
// api-server를 따로 분리
api-server/
  api-server.controller.ts
  api-server.service.ts    // 각 서비스 로직은 좀 더 생각
signalling-server/
chatting-server/
study-room/
  study-room.service.ts    // 각 서비스 로직은 좀 더 생각
  study-room.repository.ts
user/

// 각 모듈에 api-server를 위한 controller를 두기
signalling-server/
  signalling-server.gateway.ts
chatting-server/
  chatting-server.gateway.ts
study-room/
  study-room.controller.ts
  study-room.service.ts
  study-room.repository.ts
user/
  user.controller.ts
  user.service.ts
  user.repository.ts
```


## 참조 (생략 가능)
https://foamy-rose-f4f.notion.site/52c40b4f425e4cae83093a216b450f25?pvs=4
