### PR TITLE
<FE> 공부방 페이지 스톱 워치 구현

### DIFF
--- a/client/src/components/StudyRoom/StudyRoom.tsx
+++ b/client/src/components/StudyRoom/StudyRoom.tsx
@@ -76,7 +76,6 @@ const StudyRoom = () => {
           title="부스트 캠프 공부방"
           curParticipant={remoteStreamMap.current.size + 1}
           maxParticipant={16}
-          timer="01 : 49 : 29"
         />
         <VideoGrid localVideoRef={localVideoRef} remoteStreamMap={remoteStreamMap} grid={grid} />
         <ControlBar

--- a/client/src/components/StudyRoom/StudyRoomHeader.tsx
+++ b/client/src/components/StudyRoom/StudyRoomHeader.tsx
@@ -1,12 +1,12 @@
+import { useState } from 'react';
 import Header from '@components/common/Header';
 import Icon from '@components/common/Icon';
-
+import StopWatch from '@components/common/StopWatch';
 interface StudyRoomHeaderProps {
   className?: string;
   title: string;
   curParticipant: number;
   maxParticipant: number;
-  timer: string;
 }
 
 const StudyRoomHeader = ({
@@ -14,8 +14,9 @@ const StudyRoomHeader = ({
   title,
   curParticipant,
   maxParticipant,
-  timer,
 }: StudyRoomHeaderProps) => {
+  const [isStopWatchRunning, setIsStopWatchRunning] = useState(false);
+
   return (
     <Header
       className={className}
@@ -27,11 +28,15 @@ const StudyRoomHeader = ({
           </span>
         </div>
       }
-      timer={
+      stopWatch={
         <div className="flex translate-x-[1.125rem] gap-3 text-xl font-normal">
-          <div>{timer}</div>
-          <button>
-            <Icon id="pause" className="h-6 w-6"></Icon>
+          <StopWatch isRunning={isStopWatchRunning} />
+          <button
+            onClick={() => {
+              setIsStopWatchRunning(!isStopWatchRunning);
+            }}
+          >
+            <Icon id={isStopWatchRunning ? 'pause' : 'play'} className="h-6 w-6"></Icon>
           </button>
         </div>
       }

--- a/client/src/components/StudyRoom/StudyRoomHeader.tsx
+++ b/client/src/components/StudyRoom/StudyRoomHeader.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import Header from '@components/common/Header';
 import Icon from '@components/common/Icon';
 import StopWatch from '@components/common/StopWatch';
+
 interface StudyRoomHeaderProps {
   className?: string;
   title: string;

--- a/client/src/components/common/Header.tsx
+++ b/client/src/components/common/Header.tsx
@@ -3,17 +3,17 @@ import { ReactNode } from 'react';
 interface HeaderProps {
   className?: string;
   title: ReactNode;
-  timer: ReactNode;
+  stopWatch: ReactNode;
   userInfo: ReactNode;
 }
 
-const Header = ({ className, title, timer, userInfo }: HeaderProps) => {
+const Header = ({ className, title, stopWatch, userInfo }: HeaderProps) => {
   return (
     <header
       className={`border-gomz-black flex h-[4.5rem] w-[65rem] items-center justify-center border-b ${className}`}
     >
       <div className="flex w-[26rem] justify-start">{title}</div>
-      <div className="flex w-[13rem] justify-center">{timer}</div>
+      <div className="flex w-[13rem] justify-center">{stopWatch}</div>
       <div className="flex w-[26rem] justify-end">{userInfo}</div>
     </header>
   );

--- a/client/src/components/common/StopWatch.tsx
+++ b/client/src/components/common/StopWatch.tsx
@@ -1,26 +1,38 @@
-import { useState, useEffect } from 'react';
+import { useRef, useState, useEffect } from 'react';
 
 interface StopWatchProps {
   isRunning: boolean;
 }
 
 const StopWatch = ({ isRunning }: StopWatchProps) => {
-  const [time, setTime] = useState(0);
+  const startTimeRef = useRef(0); // ms
+  const [elapsedSeconds, setElapsedSeconds] = useState(0); // s
+  const [accumulatedTime, setAccumulatedTime] = useState(0); // ms
 
   useEffect(() => {
-    let intervalId: NodeJS.Timeout | number;
+    let animationFrameId: number;
+
+    const step = () => {
+      const diffTime = Date.now() - startTimeRef.current;
+      console.log(accumulatedTime);
+      setElapsedSeconds(Math.floor(diffTime / 1000));
+      animationFrameId = requestAnimationFrame(step);
+    };
+
     if (isRunning) {
-      intervalId = setInterval(() => {
-        setTime((s) => s + 1);
-      }, 1000);
+      startTimeRef.current = Date.now() - accumulatedTime;
+      animationFrameId = requestAnimationFrame(step);
+    } else {
+      setAccumulatedTime(startTimeRef.current ? Date.now() - startTimeRef.current : 0);
     }
-    return () => clearInterval(intervalId);
+
+    return () => cancelAnimationFrame(animationFrameId);
   }, [isRunning]);
 
   const formatTime = () => {
-    const hours = Math.floor(time / 3600);
-    const minutes = Math.floor((time % 3600) / 60);
-    const seconds = time % 60;
+    const hours = Math.floor(elapsedSeconds / 3600);
+    const minutes = Math.floor((elapsedSeconds % 3600) / 60);
+    const seconds = elapsedSeconds % 60;
 
     const paddedHours = hours.toString().padStart(2, '0');
     const paddedMinutes = minutes.toString().padStart(2, '0');

--- a/client/src/components/common/StopWatch.tsx
+++ b/client/src/components/common/StopWatch.tsx
@@ -14,7 +14,6 @@ const StopWatch = ({ isRunning }: StopWatchProps) => {
 
     const step = () => {
       const diffTime = Date.now() - startTimeRef.current;
-      console.log(accumulatedTime);
       setElapsedSeconds(Math.floor(diffTime / 1000));
       animationFrameId = requestAnimationFrame(step);
     };

--- a/client/src/components/common/StopWatch.tsx
+++ b/client/src/components/common/StopWatch.tsx
@@ -1,0 +1,35 @@
+import { useState, useEffect } from 'react';
+
+interface StopWatchProps {
+  isRunning: boolean;
+}
+
+const StopWatch = ({ isRunning }: StopWatchProps) => {
+  const [time, setTime] = useState(0);
+
+  useEffect(() => {
+    let intervalId: NodeJS.Timeout | number;
+    if (isRunning) {
+      intervalId = setInterval(() => {
+        setTime((s) => s + 1);
+      }, 1000);
+    }
+    return () => clearInterval(intervalId);
+  }, [isRunning]);
+
+  const formatTime = () => {
+    const hours = Math.floor(time / 3600);
+    const minutes = Math.floor((time % 3600) / 60);
+    const seconds = time % 60;
+
+    const paddedHours = hours.toString().padStart(2, '0');
+    const paddedMinutes = minutes.toString().padStart(2, '0');
+    const paddedSeconds = seconds.toString().padStart(2, '0');
+
+    return `${paddedHours} : ${paddedMinutes} : ${paddedSeconds}`;
+  };
+
+  return <div className="tabular-nums">{formatTime()}</div>;
+};
+
+export default StopWatch;


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #32 

## 소요 시간

2

## 개발한 사항

- StopWatch 컴포넌트 구현
- StopWatch 오차 개선

![Nov-14-2024 16-46-38](https://github.com/user-attachments/assets/fa26bfea-ee93-4c6d-b1e8-57ab55a4aef4)

## 고민했던 사항

- 고정폭 글꼴이 아닌 Pretendard 글꼴을 사용하여 스톱 워치 문자열이 변할 때마다 좌우로 폭이 변하는 현상을 해결하기 위해 CSS를 `font-variant-numeric: tabular-nums`으로 설정
- `setInterval`로 스톱 워치 구현할 때 생기는 오차를 수정하기 위해서 `Date.now()`의 값을 기준으로 시간을 계산함
- 부드러운 스톱워치 렌더링을 위해 `setInterval` 대신 `requestAnimationFrame`을 사용하여 실제로 렌더링되는 프레임마다 시간을 체크하여 반영

## 참고 자료

- [MDN - font-variant-numeric](https://developer.mozilla.org/en-US/docs/Web/CSS/font-variant-numeric)
- [Tailwind CSS - font-variant-numeric](https://tailwindcss.com/docs/font-variant-numeric)
- [setInterval vs. requestAnimationFrame](https://blog.makerjun.com/411591d9-c47b-4d8d-8f9e-1246d8dd1a2f)
