### PR TITLE
<FE> 뒤로가기 버튼으로 StudyRoom 퇴장하기 구현

### DIFF
--- a/client/src/components/StudyRoom/StudyRoom.tsx
+++ b/client/src/components/StudyRoom/StudyRoom.tsx
@@ -76,6 +76,8 @@ const StudyRoom = () => {
     };
 
     initStream();
+
+    return () => exitRoom();
   }, []);
 
   return (


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #47 

## 소요 시간

0.5시간

## 개발한 사항

- 뒤로가기 버튼으로 StudyRoom 퇴장하기 구현

## 고민했던 사항

- `useNavigationType`을 사용해서 뒤로가기 이벤트가 감지될 때, StudyRoom 퇴장하기를 구현하려고 하였으나 실패
- 마찬가지로 `useLocation`을 사용해서 뒤로가기 이벤트가 감지될 때, StudyRoom 퇴장하기를 구현하려고 하였으나 실패
- 실패 이유는 이미 메인 페이지로 이동한 후에 `exitRoom` 함수를 실행시켜서 작동하지 않는 것이라고 판단
- 컴포넌트가 언마운트 시 useEffect의 clean-up 함수가 실행되는 것을 이용하여 clean-up 함수에서 `exitRoom` 함수를 실행

## 참고 링크

- https://bluepebble25.tistory.com/34
