### PR TITLE
<BE> 빈 방 생성 시, userID가 두 번 들어가는 현상 수정

### DIFF
--- a/server/src/study-room/mock.repository.ts
+++ b/server/src/study-room/mock.repository.ts
@@ -5,8 +5,8 @@ import { StudyRoom } from './study-room.entity';
 export class MockStudyRoomRepository {
   private rooms: Map<string, StudyRoom> = new Map();
 
-  createRoom(roomId: string, clientId: string): StudyRoom {
-    const newRoom = new StudyRoom(roomId, clientId);
+  createRoom(roomId: string): StudyRoom {
+    const newRoom = new StudyRoom(roomId);
     this.rooms.set(roomId, newRoom);
     return newRoom;
   }
@@ -18,7 +18,7 @@ export class MockStudyRoomRepository {
   addUserToRoom(roomId: string, clientId: string) {
     const room = this.rooms.get(roomId);
     if (!room) {
-      this.createRoom(roomId, clientId);
+      this.createRoom(roomId);
     }
     this.rooms.get(roomId)?.users.push(clientId);
   }

--- a/server/src/study-room/study-room.entity.ts
+++ b/server/src/study-room/study-room.entity.ts
@@ -2,8 +2,8 @@ export class StudyRoom {
   roomId: string;
   users: string[];
 
-  constructor(roomId: string, clientId: string) {
+  constructor(roomId: string) {
     this.roomId = roomId;
-    this.users = [clientId];
+    this.users = [];
   }
 }

--- a/server/src/study-room/study-room.service.ts
+++ b/server/src/study-room/study-room.service.ts
@@ -13,7 +13,9 @@ export class StudyRoomsService {
    * @returns 생성된 방
    */
   createRoom(roomId: string, clientId: string): StudyRoom {
-    return this.roomRepository.createRoom(roomId, clientId);
+    const studyRoom = this.roomRepository.createRoom(roomId);
+    this.roomRepository.addUserToRoom(roomId, clientId);
+    return studyRoom;
   }
 
   /**


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #119 

## 소요 시간

10분

## 개발한 사항
| <BE> 빈 방 생성 시, userID가 두 번 들어가는 현상 수정

- repository에서 방 생성, 유저 입장 로직 분리

## 고민했던 사항

## 참조 (생략 가능)

![image](https://github.com/user-attachments/assets/be29e9dd-342e-4928-b02c-5703642a66f1)
