### PR TITLE
<BE> 시그널링 소켓 연결해제시 이벤트 전송

### DIFF
--- a/server/src/chatting-server/chatting-server.module.ts
+++ b/server/src/chatting-server/chatting-server.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ChattingServerGateway } from './chatting-server.gateway';
-import { StudyRoomModule } from 'src/study-room/study-room.module';
+import { StudyRoomModule } from '../study-room/study-room.module';
 
 @Module({
   imports: [StudyRoomModule],

--- a/server/src/signaling-server/signaling-server.gateway.ts
+++ b/server/src/signaling-server/signaling-server.gateway.ts
@@ -26,16 +26,21 @@ export class SignalingServerGateway implements OnGatewayConnection, OnGatewayDis
 
   // 1. 신규 참가자가 접속을 요청한다. 그리고 방에 있는 기존 참가자들 소켓 정보를 반환한다.
   handleConnection(client: Socket) {
-    this.logger.info(`${client.id} 접속!!!`);
     const defaultRoom = '1';
     this.studyRoomsService.addUserToRoom(defaultRoom, client.id);
     const users = this.studyRoomsService.getRoomUsers(defaultRoom).filter((id) => id !== client.id);
+    this.logger.info(`${client.id} 접속!!! [${users}]`);
     client.emit('offerRequest', JSON.stringify({ users }));
   }
 
   handleDisconnect(client: Socket) {
+    const defaultRoom = '1';
     this.logger.info(`${client.id} 접속해제!!!`);
     this.studyRoomsService.leaveAllRooms(client.id);
+    const users = this.studyRoomsService.getRoomUsers(defaultRoom);
+    for (const userId of users) {
+      this.server.to(userId).emit('userDisconnected', JSON.stringify({ targetId: client.id }));
+    }
   }
 
   // 2. 신규 참가자가 기존 참가자들에게 offer를 보낸다.
@@ -46,7 +51,9 @@ export class SignalingServerGateway implements OnGatewayConnection, OnGatewayDis
     @MessageBody('oldId') oldId: string,
     @MessageBody('newRandomId') newRandomId: string,
   ) {
-    this.logger.info(`new user: ${client.id}(${newRandomId}) sends an offer to old user: ${oldId}`);
+    this.logger.silly(
+      `new user: ${client.id}(${newRandomId}) sends an offer to old user: ${oldId}`,
+    );
     this.server
       .to(oldId)
       .emit('answerRequest', JSON.stringify({ newId: client.id, offer, newRandomId }));
@@ -60,7 +67,7 @@ export class SignalingServerGateway implements OnGatewayConnection, OnGatewayDis
     @MessageBody('newId') newId: string,
     @MessageBody('oldRandomId') oldRandomId: string,
   ) {
-    this.logger.info(
+    this.logger.silly(
       `old user: ${client.id}(${oldRandomId}) sends an answer to new user: ${newId}`,
     );
     this.server
@@ -74,7 +81,7 @@ export class SignalingServerGateway implements OnGatewayConnection, OnGatewayDis
     @MessageBody('targetId') targetId: string,
     @MessageBody('iceCandidate') candidate: RTCIceCandidateInit,
   ) {
-    this.logger.info(`user: ${client.id} sends ICE candidate to user: ${targetId}`);
+    this.logger.silly(`user: ${client.id} sends ICE candidate to user: ${targetId}`);
     this.server
       .to(targetId)
       .emit('setIceCandidate', JSON.stringify({ senderId: client.id, iceCandidate: candidate }));


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #124

## 소요 시간

2시간

## 개발한 사항

- 시그널링 소켓 서버 연결해제시 방에 있는 모든 소켓에 `userDisconnected` 이벤트 전송
- `userDisconnected` 이벤트에 targetId로 연결해제한 소켓 아이디 전송
```ts
handleDisconnect(client: Socket) {
  ...
  this.studyRoomsService.leaveAllRooms(client.id); // 공부방에서 나가기
  const users = this.studyRoomsService.getRoomUsers(defaultRoom); // 공부방에 남아있는 유저 리스트
  for (const userId of users) { // 공부방에 남아있는 유저들에게 이벤트 전송
    this.server.to(userId).emit('userDisconnected', JSON.stringify({ targetId: client.id }));
  }
}
```
- 해당 기능 e2e 테스트 코드 작성

## 고민했던 사항

## 참조 (생략 가능)

