### PR TITLE
<BE> 공부방 참가 이벤트 joinRoom 구현

### DIFF
--- a/server/src/chatting-server/chatting-server.gateway.ts
+++ b/server/src/chatting-server/chatting-server.gateway.ts
@@ -1,8 +1,6 @@
 import {
   ConnectedSocket,
   MessageBody,
-  OnGatewayConnection,
-  OnGatewayDisconnect,
   SubscribeMessage,
   WebSocketGateway,
   WebSocketServer,
@@ -14,7 +12,7 @@ import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 
 @WebSocketGateway({ cors: { origin: '*' } })
-export class ChattingServerGateway implements OnGatewayConnection, OnGatewayDisconnect {
+export class ChattingServerGateway {
   constructor(
     @Inject(WINSTON_MODULE_PROVIDER)
     private readonly logger: Logger,
@@ -23,15 +21,6 @@ export class ChattingServerGateway implements OnGatewayConnection, OnGatewayDisc
 
   @WebSocketServer()
   server: Server;
-
-  async handleConnection(client: Socket) {
-    this.logger.info(`Client connected: ${client.id}`);
-  }
-
-  async handleDisconnect(client: Socket) {
-    this.logger.info(`Client disconnected: ${client.id}`);
-    await this.studyRoomsService.leaveAllRooms(client.id);
-  }
 
   // 메시지 전송
   @SubscribeMessage('sendMessage')

--- a/server/src/signaling-server/signaling-server.gateway.ts
+++ b/server/src/signaling-server/signaling-server.gateway.ts
@@ -29,9 +29,7 @@ export class SignalingServerGateway implements OnGatewayDisconnect {
     this.studyRoomsService.removeUserFromRoom(roomId, client.id);
     const users = await this.studyRoomsService.getRoomUsers(roomId);
     for (const userId of users) {
-      this.server
-        .to(userId.socketId)
-        .emit('userDisconnected', JSON.stringify({ targetId: client.id }));
+      this.server.to(userId.socketId).emit('userDisconnected', { targetId: client.id });
     }
     this.logger.info(`${client.id} 접속해제!!!`);
   }
@@ -56,9 +54,7 @@ export class SignalingServerGateway implements OnGatewayDisconnect {
     this.logger.silly(
       `new user: ${client.id}(${newRandomId}) sends an offer to old user: ${oldId}`,
     );
-    this.server
-      .to(oldId)
-      .emit('answerRequest', JSON.stringify({ newId: client.id, offer, newRandomId }));
+    this.server.to(oldId).emit('answerRequest', { newId: client.id, offer, newRandomId });
   }
 
   // 3. 기존 참가자들은 신규 참가자에게 answer를 보낸다.
@@ -72,14 +68,11 @@ export class SignalingServerGateway implements OnGatewayDisconnect {
     this.logger.silly(
       `old user: ${client.id}(${oldRandomId}) sends an answer to new user: ${newId}`,
     );
-    this.server.to(newId).emit(
-      'completeConnection',
-      JSON.stringify({
-        oldId: client.id,
-        answer,
-        oldRandomId,
-      }),
-    );
+    this.server.to(newId).emit('completeConnection', {
+      oldId: client.id,
+      answer,
+      oldRandomId,
+    });
   }
 
   // 4. 참가자들간에 icecandidate를 주고 받는다.
@@ -92,6 +85,6 @@ export class SignalingServerGateway implements OnGatewayDisconnect {
     this.logger.silly(`user: ${client.id} sends ICE candidate to user: ${targetId}`);
     this.server
       .to(targetId)
-      .emit('setIceCandidate', JSON.stringify({ senderId: client.id, iceCandidate: candidate }));
+      .emit('setIceCandidate', { senderId: client.id, iceCandidate: candidate });
   }
 }


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #81

## 소요 시간

2시간

## 개발한 사항

- 시그널링 서버에서 소켓 연결됐을 때 offerRequest 전송하는 부분 제거
- 시그널링 서버에서 joinRoom 이벤트 생성
  - joinRoom 이벤트 발생시 해당 소켓을 roomId의 공부방에 추가
  - 자신을 제외한 현재 공부방 소켓 id offerRequest로 전송

![image](https://github.com/user-attachments/assets/8e7d0861-1f45-435e-ac00-076b6bd19a5e)

## 고민했던 사항

- https://www.notion.so/9926be459acd4066aa44f7059686e92a?v=a08a2f50b280493facd53b1b189d53f5&p=2f691db9a9104f56823b9b928ce37248&pm=s
