### PR TITLE
<BE> 입장 확인 수정, 방 리스트 반환 정보 수정

### DIFF
--- a/server/src/study-room/study-room.controller.ts
+++ b/server/src/study-room/study-room.controller.ts
@@ -13,7 +13,7 @@ export class StudyRoomController {
   ) {}
 
   @Post('/create')
-  async creatRoom(
+  creatRoom(
     @Body('roomName') roomName: string,
     @Body('clientId') clientId: string,
   ): Promise<StudyRoom> {

--- a/server/src/study-room/study-room.controller.ts
+++ b/server/src/study-room/study-room.controller.ts
@@ -21,7 +21,9 @@ export class StudyRoomController {
   }
 
   @Get('/rooms')
-  async getAllRooms(): Promise<{ roomId: string; users: { socketId: string }[] }[]> {
+  async getAllRooms(): Promise<
+    { roomId: string; roomName: string; users: { socketId: string }[] }[]
+  > {
     return await this.studyRoomService.getAllRoom();
   }
 

--- a/server/src/study-room/study-room.service.ts
+++ b/server/src/study-room/study-room.service.ts
@@ -87,12 +87,21 @@ export class StudyRoomsService {
   /**
    * 존재하는 모든 방을 조회합니다.
    */
-  async getAllRoom(): Promise<{ roomId: string; users: { socketId: string }[] }[]> {
+  async getAllRoom(): Promise<
+    { roomId: string; roomName: string; users: { socketId: string }[] }[]
+  > {
     const allRooms = await this.participantRepository.getAllRooms();
-    return Object.keys(allRooms).map((roomId) => ({
-      roomId,
-      users: allRooms[roomId],
-    }));
+
+    return await Promise.all(
+      Object.keys(allRooms).map(async (roomId) => {
+        const room = await this.roomRepository.findRoom(parseInt(roomId, 10));
+        return {
+          roomId,
+          roomName: room.room_name,
+          users: allRooms[roomId],
+        };
+      }),
+    );
   }
 
   private async isValidRoom(roomId: string): Promise<void> {

--- a/server/src/study-room/study-room.service.ts
+++ b/server/src/study-room/study-room.service.ts
@@ -123,7 +123,7 @@ export class StudyRoomsService {
     }
 
     // 비밀번호 체크
-    if (password !== studyRoom.password) {
+    if (studyRoom.password && password !== studyRoom.password) {
       throw new UnauthorizedException('Passwords do not match');
     }
 


### PR DESCRIPTION
# 제목: <FE/BE> 작업 내용 요약 (제목 기입 후 삭제해주세요)

## 이슈(수동으로 한 경우 따로 기입)

resolve #134

## 소요 시간
20분
## 개발한 사항
- 입장 확인 수정
  - 방 자체가 공개방인 경우 비밀번호 확인 실행 X
- 방 리스트 반환 정보 수정 
  - roomId랑 user 정보만 반환 -> 방 이름도 추가

## 고민했던 사항
- 방 리스트 정보를 반환할 때, 방 제목도 같이 반환하고 싶은데  participantRepository.getAllRooms()에는 방 정보가 존재하지 않음.
- map() 내부에서 리포지토리를 통해 방 정보를 가져오도록 수정 
- 다만, 리포지토리 반환 값이 Promise 이기 때문에 배열 하나의 원소마다 각각 비동기 작업이 존재함.
- 따라서 Promise.all()을 통해 배열의 모든 비동기 작업이 완료 후 반환
```ts

const allRooms = await this.participantRepository.getAllRooms();

return await Promise.all(
      Object.keys(allRooms).map(async (roomId) => {
        const room = await this.roomRepository.findRoom(parseInt(roomId, 10));
        return {
          roomId,
          roomName: room.room_name,
          users: allRooms[roomId],
        };
      }),
    );
```
