### PR TITLE
<BE> signalling-server에서 JSON이 아닌 Object를 보내는 현상

### DIFF
--- a/server/src/signaling-server/signaling-server.gateway.ts
+++ b/server/src/signaling-server/signaling-server.gateway.ts
@@ -38,7 +38,7 @@ export class SignalingServerGateway implements OnGatewayConnection, OnGatewayDis
     );
 
     // 기존 사용자 목록 전송
-    client.emit('offerRequest', { users });
+    client.emit('offerRequest', JSON.stringify({ users }));
   }
 
   async handleDisconnect(client: Socket) {
@@ -80,11 +80,14 @@ export class SignalingServerGateway implements OnGatewayConnection, OnGatewayDis
     this.logger.silly(
       `old user: ${client.id}(${oldRandomId}) sends an answer to new user: ${newId}`,
     );
-    this.server.to(newId).emit('completeConnection', {
-      oldId: client.id,
-      answer,
-      oldRandomId,
-    });
+    this.server.to(newId).emit(
+      'completeConnection',
+      JSON.stringify({
+        oldId: client.id,
+        answer,
+        oldRandomId,
+      }),
+    );
   }
 
   @SubscribeMessage('sendIceCandidate')


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #139 

## 소요 시간
5분

## 개발한 사항

- signalling-server에서 `JSON.stringify`로 객체 전달하도록 수정