### PR TITLE
<BE> joinRoom 자신 제외 안되는 버그 수정

### DIFF
--- a/server/src/signaling-server/signaling-server.gateway.ts
+++ b/server/src/signaling-server/signaling-server.gateway.ts
@@ -37,10 +37,12 @@ export class SignalingServerGateway implements OnGatewayDisconnect {
   // 1. 신규 참가자가 공부방 입장을 요청한다. 그리고 방에 있는 기존 참가자들 소켓 정보를 반환한다.
   @SubscribeMessage('joinRoom')
   async handleJoinRoom(@ConnectedSocket() client: Socket, @MessageBody('roomId') roomId: string) {
-    const users = await this.studyRoomsService.getRoomUsers(roomId);
+    const users = (await this.studyRoomsService.getRoomUsers(roomId)).filter(
+      (user) => user.socketId !== client.id,
+    );
     await this.studyRoomsService.addUserToRoom(roomId, client.id);
     client.emit('offerRequest', { users });
-    this.logger.info(`${client.id} 접속, [${users}]`);
+    this.logger.info(`${client.id} 접속, ${JSON.stringify(users)}`);
   }
 
   // 2. 신규 참가자가 기존 참가자들에게 offer를 보낸다.


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #147

## 소요 시간

0.2시간

## 개발한 사항

- joinRoom 이벤트에서 자신의 socketId 제외 안되는 버그 수정
- 로그 찍을때 [Object object] 문제 JSON.stringify로 수정


## 고민했던 사항

- 개발하며 고민했던 내용 혹은 고민했던 내용을 적은 노션 링크를 적어주세요.

## 참조 (생략 가능)

- 개발 시 참조했던 자료나 링크를 첨부해 주세요.
