### PR TITLE
<BE> 시그널링 소켓 joinRoom 안하고 연결해제하면 발생하는 오류 수정

### DIFF
--- a/server/src/signaling-server/signaling-server.gateway.ts
+++ b/server/src/signaling-server/signaling-server.gateway.ts
@@ -26,6 +26,7 @@ export class SignalingServerGateway implements OnGatewayDisconnect {
   // 5. 참가자가 공부방을 나갔을 때 방에 있는 참가자들에게 퇴장인원 소켓 정보를 전달한다
   async handleDisconnect(client: Socket) {
     const roomId = await this.studyRoomsService.findUserRoom(client.id);
+    if (roomId === undefined) return;
     this.studyRoomsService.removeUserFromRoom(roomId, client.id);
     const users = await this.studyRoomsService.getRoomUsers(roomId);
     for (const userId of users) {


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #151

## 소요 시간

0.5시간

## 개발한 사항

- 소켓이 연결해제할때 현재 소켓의 공부방이 지정되어있지 않으면 추가 작업없이 바로 연결해제

## 고민했던 사항

- 시그널링 서버에 연결후 joinRoom 이벤트 없이 바로 연결해제하면 다음 SQL 오류가 발생
![image](https://github.com/user-attachments/assets/394ad99c-9b55-40c4-97fe-bfbc617eea68)

- 다음 코드에서 `roomId`가 `undefined` 여서 에러가 나는걸로 확인
- `removeUserFromRoom` 에서 `roomId`가 `undefined`이면 SQL에서 `WHERE=NaN` 이여서 에러가 남
- 만약 소켓이 `joinRoom`을 안하면 공부방에 입장을 안해서 `findUserRoom` 해도 방id를 찾을수 없는 거였음
```ts
async handleDisconnect(client: Socket) {
  const roomId = await this.studyRoomsService.findUserRoom(client.id);
  this.studyRoomsService.removeUserFromRoom(roomId, client.id);
  const users = await this.studyRoomsService.getRoomUsers(roomId);
  ...
}
```

- 다음같이 `roomId` `undefined` 체크를 해주어서 `joinRoom`을 안했을때 바로 `return` 해서 문제해결
```ts
async handleDisconnect(client: Socket) {
  const roomId = await this.studyRoomsService.findUserRoom(client.id);
  if (roomId === undefined) return;
  this.studyRoomsService.removeUserFromRoom(roomId, client.id);
  const users = await this.studyRoomsService.getRoomUsers(roomId);
  ...
}
```

## 참조 (생략 가능)

- 개발 시 참조했던 자료나 링크를 첨부해 주세요.
