### PR TITLE
<BE> 입력받은 정보로 방을 생성한다, 리스트를 반환한다.

### DIFF
--- a/server/src/study-room/entity/study-room.entity.ts
+++ b/server/src/study-room/entity/study-room.entity.ts
@@ -11,8 +11,8 @@ export class StudyRoom {
   @CreateDateColumn({ type: 'timestamp' })
   created_at: Date;
 
-  @Column({ type: 'int', nullable: false })
-  category_id: number;
+  @Column({ type: 'varchar', nullable: false })
+  category_name: string;
 
   @BeforeInsert()
   setCreatedAt() {

--- a/server/src/study-room/entity/study-room.entity.ts
+++ b/server/src/study-room/entity/study-room.entity.ts
@@ -21,7 +21,4 @@ export class StudyRoom {
 
   @Column({ type: 'varchar', length: 45, nullable: true })
   password: string;
-
-  @Column({ type: 'boolean' })
-  is_private: boolean;
 }

--- a/server/src/study-room/entity/study-room.entity.ts
+++ b/server/src/study-room/entity/study-room.entity.ts
@@ -21,4 +21,7 @@ export class StudyRoom {
 
   @Column({ type: 'varchar', length: 45, nullable: true })
   password: string;
+
+  @Column({ type: 'boolean' })
+  is_private: boolean;
 }

--- a/server/src/study-room/repository/study-room.repository.ts
+++ b/server/src/study-room/repository/study-room.repository.ts
@@ -11,10 +11,11 @@ export class StudyRoomRepository {
   ) {}
 
   // 방 생성
-  async createRoom(roomName: string, categoryId: number): Promise<StudyRoom> {
+  async createRoom(roomName: string, password: string, categoryName: string): Promise<StudyRoom> {
     const newRoom = this.repository.create({
       room_name: roomName,
-      category_id: categoryId,
+      password: password,
+      category_name: categoryName,
     });
 
     return await this.repository.save(newRoom);

--- a/server/src/study-room/study-room.controller.spec.ts
+++ b/server/src/study-room/study-room.controller.spec.ts
@@ -1,32 +1,33 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { StudyRoomController } from './study-room.controller';
 import { StudyRoomsService } from './study-room.service';
+import { StudyRoom } from './entity/study-room.entity';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
-import { Logger } from 'winston';
 
-describe('Study Room 컨트롤러  테스트', () => {
+describe('Study Room 컨트롤러 테스트', () => {
   let controller: StudyRoomController;
   let service: StudyRoomsService;
 
   beforeEach(async () => {
-    const mockLogger = { info: jest.fn(), error: jest.fn() } as unknown as Logger;
-
-    const mockService = {
-      createRoom: jest.fn(),
-      getAllRoom: jest.fn(),
-      checkAccess: jest.fn(),
-    };
-
     const module: TestingModule = await Test.createTestingModule({
       controllers: [StudyRoomController],
       providers: [
         {
           provide: StudyRoomsService,
-          useValue: mockService,
+          useValue: {
+            createRoom: jest.fn(),
+            getAllRoom: jest.fn(),
+          },
         },
         {
           provide: WINSTON_MODULE_PROVIDER,
-          useValue: mockLogger,
+          useValue: {
+            log: jest.fn(),
+            error: jest.fn(),
+            warn: jest.fn(),
+            debug: jest.fn(),
+            verbose: jest.fn(),
+          },
         },
       ],
     }).compile();
@@ -35,76 +36,56 @@ describe('Study Room 컨트롤러  테스트', () => {
     service = module.get<StudyRoomsService>(StudyRoomsService);
   });
 
-  describe('POST /create 요청', () => {
-    it('방을 생성하고 결과를 반환해야 한다.', async () => {
-      const mockRoom = {
+  describe('클라이언트가 방 생성을 요청할 때', () => {
+    it('새로운 방을 생성한다.', async () => {
+      const roomName = 'testRoom';
+      const password = null;
+      const categoryName = '#test';
+
+      const mockStudyRoom: StudyRoom = {
         room_id: 1,
-        room_name: 'Test Room',
-        category_id: 0,
+        room_name: 'testRoom',
+        category_name: '#test',
         created_at: new Date(),
         setCreatedAt: jest.fn(),
-        password: '',
+        password: null,
       };
-      jest.spyOn(service, 'createRoom').mockResolvedValue(mockRoom);
 
-      const roomName = 'Test Room';
-      const clientId = 'socket123';
-      const result = await controller.creatRoom(roomName, clientId);
+      jest.spyOn(service, 'createRoom').mockResolvedValue({ roomId: 1 });
 
-      expect(service.createRoom).toHaveBeenCalledWith(roomName, clientId);
-      expect(result).toEqual(mockRoom);
+      const result = await service.createRoom(roomName, password, categoryName);
+
+      expect(service.createRoom).toHaveBeenCalledWith(roomName, password, categoryName);
+      expect(result.roomId).toEqual(mockStudyRoom.room_id);
     });
   });
 
-  describe('GET /rooms 요청', () => {
-    it('모든 방 목록을 반환해야 한다.', async () => {
+  describe('클라이언트가 방 조회를 요청할 때', () => {
+    it('모든 방을 조회한다.', async () => {
       const mockRooms = [
         {
-          roomId: '1',
-          roomName: 'Room 1',
-          users: [{ socketId: 'user1' }],
+          roomId: 19,
+          roomName: 'random1',
+          categoryName: '#DB',
+          isPrivate: false,
+          curParticipant: 1,
+          maxParticipant: 8,
         },
         {
-          roomId: '2',
-          roomName: 'Room 2',
-          users: [{ socketId: 'user2' }],
+          roomId: 20,
+          roomName: 'random2',
+          categoryName: '#OS',
+          isPrivate: false,
+          curParticipant: 1,
+          maxParticipant: 8,
         },
       ];
+
       jest.spyOn(service, 'getAllRoom').mockResolvedValue(mockRooms);
 
       const result = await controller.getAllRooms();
-
       expect(service.getAllRoom).toHaveBeenCalled();
       expect(result).toEqual(mockRooms);
-    });
-  });
-
-  describe('GET /check 요청', () => {
-    it('올바른 비밀번호로 접근 시 canAccess: true를 반환해야 한다.', async () => {
-      const password = 'correct_password';
-      const roomId = 1;
-
-      jest.spyOn(service, 'checkAccess').mockResolvedValue(true);
-
-      const result = await controller.checkAccess(password, roomId);
-
-      expect(service.checkAccess).toHaveBeenCalledWith(password, roomId);
-      expect(result).toEqual({ canAccess: true });
-    });
-
-    it('잘못된 비밀번호로 접근 시 canAccess: false와 에러를 반환해야 한다.', async () => {
-      const password = 'wrong_password';
-      const roomId = 1;
-
-      jest.spyOn(service, 'checkAccess').mockRejectedValue(new Error('Unauthorized'));
-
-      const result = await controller.checkAccess(password, roomId);
-
-      expect(service.checkAccess).toHaveBeenCalledWith(password, roomId);
-      expect(result).toEqual({
-        canAccess: false,
-        error: expect.any(Error),
-      });
     });
   });
 });

--- a/server/src/study-room/study-room.controller.spec.ts
+++ b/server/src/study-room/study-room.controller.spec.ts
@@ -36,8 +36,8 @@ describe('Study Room 컨트롤러 테스트', () => {
     service = module.get<StudyRoomsService>(StudyRoomsService);
   });
 
-  describe('클라이언트가 방 생성을 요청할 때', () => {
-    it('새로운 방을 생성한다.', async () => {
+  describe('POST /create 요청', () => {
+    it('방을 생성하고 결과를 반환해야 한다.', async () => {
       const roomName = 'testRoom';
       const password = null;
       const categoryName = '#test';
@@ -60,8 +60,8 @@ describe('Study Room 컨트롤러 테스트', () => {
     });
   });
 
-  describe('클라이언트가 방 조회를 요청할 때', () => {
-    it('모든 방을 조회한다.', async () => {
+  describe('GET /rooms 요청', () => {
+    it('모든 방 목록을 반환해야 한다.', async () => {
       const mockRooms = [
         {
           roomId: 19,

--- a/server/src/study-room/study-room.controller.ts
+++ b/server/src/study-room/study-room.controller.ts
@@ -23,7 +23,7 @@ export class StudyRoomController {
   @Get('/rooms')
   async getAllRooms(): Promise<
     {
-      roomId: string;
+      roomId: number;
       roomName: string;
       categoryName: string;
       isPrivate: boolean;

--- a/server/src/study-room/study-room.controller.ts
+++ b/server/src/study-room/study-room.controller.ts
@@ -15,9 +15,10 @@ export class StudyRoomController {
   @Post('/create')
   creatRoom(
     @Body('roomName') roomName: string,
-    @Body('clientId') clientId: string,
+    @Body('password') password: string,
+    @Body('categoryName') categoryName: string,
   ): Promise<StudyRoom> {
-    return this.studyRoomService.createRoom(roomName, clientId);
+    return this.studyRoomService.createRoom(roomName, password, categoryName);
   }
 
   @Get('/rooms')

--- a/server/src/study-room/study-room.controller.ts
+++ b/server/src/study-room/study-room.controller.ts
@@ -1,6 +1,5 @@
 import { Body, Controller, Get, Inject, ParseIntPipe, Post, Query } from '@nestjs/common';
 import { StudyRoomsService } from './study-room.service';
-import { StudyRoom } from './entity/study-room.entity';
 import { WINSTON_MODULE_PROVIDER } from 'nest-winston';
 import { Logger } from 'winston';
 
@@ -17,7 +16,7 @@ export class StudyRoomController {
     @Body('roomName') roomName: string,
     @Body('password') password: string,
     @Body('categoryName') categoryName: string,
-  ): Promise<StudyRoom> {
+  ): Promise<{ roomId: number }> {
     return this.studyRoomService.createRoom(roomName, password, categoryName);
   }
 

--- a/server/src/study-room/study-room.controller.ts
+++ b/server/src/study-room/study-room.controller.ts
@@ -23,7 +23,14 @@ export class StudyRoomController {
 
   @Get('/rooms')
   async getAllRooms(): Promise<
-    { roomId: string; roomName: string; users: { socketId: string }[] }[]
+    {
+      roomId: string;
+      roomName: string;
+      categoryName: string;
+      isPrivate: boolean;
+      curParticipant: number;
+      maxParticipant: number;
+    }[]
   > {
     return await this.studyRoomService.getAllRoom();
   }

--- a/server/src/study-room/study-room.service.ts
+++ b/server/src/study-room/study-room.service.ts
@@ -18,9 +18,8 @@ export class StudyRoomsService {
    */
   // TODO 생성된 방 entity를 그대로 주는 것보다 방 생성 성공 여부를 가르는 것은 어떤가요.
   // TODO 나중에는 카테고리 ID도 필요해요.
-  async createRoom(roomName: string, clientId: string): Promise<StudyRoom> {
-    const studyRoom = await this.roomRepository.createRoom(roomName, 0);
-    this.participantRepository.addUserToRoom(studyRoom.room_id, clientId);
+  async createRoom(roomName: string, password: string, categoryName: string): Promise<StudyRoom> {
+    const studyRoom = await this.roomRepository.createRoom(roomName, password, categoryName);
     return studyRoom;
   }
 

--- a/server/src/study-room/study-room.service.ts
+++ b/server/src/study-room/study-room.service.ts
@@ -12,8 +12,9 @@ export class StudyRoomsService {
 
   /**
    * 새로운 방을 생성합니다.
-   * @param roomName 방 ID
-   * @param clientId 생성자 ID
+   * @param roomName 방 제목
+   * @param password 방 비밀번호
+   * @param categoryName 방 카테고리 명
    * @returns 생성된 방
    */
   // TODO 생성된 방 entity를 그대로 주는 것보다 방 생성 성공 여부를 가르는 것은 어떤가요.
@@ -86,7 +87,14 @@ export class StudyRoomsService {
    * 존재하는 모든 방을 조회합니다.
    */
   async getAllRoom(): Promise<
-    { roomId: string; roomName: string; users: { socketId: string }[] }[]
+    {
+      roomId: string;
+      roomName: string;
+      categoryName: string;
+      isPrivate: boolean;
+      curParticipant: number;
+      maxParticipant: number;
+    }[]
   > {
     const allRooms = await this.participantRepository.getAllRooms();
 
@@ -96,7 +104,10 @@ export class StudyRoomsService {
         return {
           roomId,
           roomName: room.room_name,
-          users: allRooms[roomId],
+          categoryName: room.category_name,
+          isPrivate: !!room.password,
+          curParticipant: allRooms[roomId].length,
+          maxParticipant: 8,
         };
       }),
     );

--- a/server/src/study-room/study-room.service.ts
+++ b/server/src/study-room/study-room.service.ts
@@ -19,8 +19,13 @@ export class StudyRoomsService {
    */
   // TODO 생성된 방 entity를 그대로 주는 것보다 방 생성 성공 여부를 가르는 것은 어떤가요.
   // TODO 나중에는 카테고리 ID도 필요해요.
-  async createRoom(roomName: string, password: string, categoryName: string): Promise<StudyRoom> {
-    return await this.roomRepository.createRoom(roomName, password, categoryName);
+  async createRoom(
+    roomName: string,
+    password: string,
+    categoryName: string,
+  ): Promise<{ roomId: number }> {
+    const studyRoom = await this.roomRepository.createRoom(roomName, password, categoryName);
+    return { roomId: studyRoom.room_id };
   }
 
   /**

--- a/server/src/study-room/study-room.service.ts
+++ b/server/src/study-room/study-room.service.ts
@@ -19,8 +19,7 @@ export class StudyRoomsService {
   // TODO 생성된 방 entity를 그대로 주는 것보다 방 생성 성공 여부를 가르는 것은 어떤가요.
   // TODO 나중에는 카테고리 ID도 필요해요.
   async createRoom(roomName: string, password: string, categoryName: string): Promise<StudyRoom> {
-    const studyRoom = await this.roomRepository.createRoom(roomName, password, categoryName);
-    return studyRoom;
+    return await this.roomRepository.createRoom(roomName, password, categoryName);
   }
 
   /**
@@ -106,7 +105,7 @@ export class StudyRoomsService {
   private async isValidRoom(roomId: string): Promise<void> {
     const room = await this.roomRepository.findRoom(parseInt(roomId, 10));
     if (!room) {
-      this.roomRepository.createRoom('테스트용 방', 0);
+      this.roomRepository.createRoom('테스트용 방', null, '#test');
       // throw new Error('Room not found');
     }
   }

--- a/server/src/study-room/study-room.service.ts
+++ b/server/src/study-room/study-room.service.ts
@@ -93,7 +93,7 @@ export class StudyRoomsService {
    */
   async getAllRoom(): Promise<
     {
-      roomId: string;
+      roomId: number;
       roomName: string;
       categoryName: string;
       isPrivate: boolean;
@@ -107,7 +107,7 @@ export class StudyRoomsService {
       Object.keys(allRooms).map(async (roomId) => {
         const room = await this.roomRepository.findRoom(parseInt(roomId, 10));
         return {
-          roomId,
+          roomId: parseInt(roomId, 10),
           roomName: room.room_name,
           categoryName: room.category_name,
           isPrivate: !!room.password,


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #146

## 소요 시간
3시간
## 개발한 사항

- 방 생성 controller에서 받는 request 정보 수정
- 방 생성시 client response 정보 수정(roomId만)
```ts
@Post('/create')
  creatRoom(
    @Body('roomName') roomName: string,
    @Body('password') password: string,
    @Body('categoryName') categoryName: string,
  ): Promise<{ roomId: number }> {
    return this.studyRoomService.createRoom(roomName, password, categoryName);
  }
```
- 방 리스트 정보 반환 시 추가적으로 필요한 정보 반환.
```ts
const allRooms = await this.participantRepository.getAllRooms();

    return await Promise.all(
      Object.keys(allRooms).map(async (roomId) => {
        const room = await this.roomRepository.findRoom(parseInt(roomId, 10));
        return {
          roomId: parseInt(roomId, 10),
          roomName: room.room_name,
          categoryName: room.category_name,
          isPrivate: !!room.password,
          curParticipant: allRooms[roomId].length,
          maxParticipant: 8,
        };
      }),
    );
```
- 관련 테스트 코드 수정

## 고민했던 사항
- 방 생성 + 방 리스트 API에서 client에게 반환할 정보에 대해
- roomId의 반환 타입(string vs number)
## 참조 (생략 가능)
- https://www.notion.so/payload-parameter-3e4c738969db4dbebc216da0ec78eab7
