### PR TITLE
<FE> 카메라를 키면 비디오 트랙이 추가되고, 끄면 제거되도록 개선

### DIFF
--- a/client/src/components/StudyRoom/ControlBar.tsx
+++ b/client/src/components/StudyRoom/ControlBar.tsx
@@ -3,7 +3,7 @@ import Icon from '@components/common/Icon';
 
 interface ControlBarProps {
   className?: string;
-  toggleVideo: () => boolean;
+  toggleVideo: () => Promise<boolean>;
   toggleMic: () => boolean;
   toggleChat: () => void;
   exitRoom: () => void;
@@ -24,7 +24,7 @@ const ControlBar = ({
   return (
     <div className={`flex gap-12 ${className}`}>
       <button
-        onClick={() => setIsVideoOn(toggleVideo())}
+        onClick={() => toggleVideo().then((result) => setIsVideoOn(result))}
         className="bg-gomz-black flex h-10 w-10 items-center justify-center rounded-full"
       >
         <Icon

--- a/client/src/socket/signalingClient.ts
+++ b/client/src/socket/signalingClient.ts
@@ -40,14 +40,6 @@ const signalingClient = (localStream: MediaStream, webRTCMap: Map<string, WebRTC
     }
   };
 
-  const isDisconnected = (peerConnection: RTCPeerConnection) => {
-    return (
-      peerConnection.connectionState === 'disconnected' ||
-      peerConnection.connectionState === 'failed' ||
-      peerConnection.connectionState === 'closed'
-    );
-  };
-
   const handlePeerDisconnection = (peerConnection: RTCPeerConnection, targetId: string) => {
     webRTCMap.delete(targetId);
     pendingConnectionsMap.delete(targetId);
@@ -70,12 +62,6 @@ const signalingClient = (localStream: MediaStream, webRTCMap: Map<string, WebRTC
       peerConnection.onicecandidate = ({ candidate }) => {
         if (candidate) {
           socket.emit('sendIceCandidate', { targetId: oldId, iceCandidate: candidate });
-        }
-      };
-
-      peerConnection.onconnectionstatechange = () => {
-        if (isDisconnected(peerConnection)) {
-          handlePeerDisconnection(peerConnection, oldId);
         }
       };
 
@@ -107,12 +93,6 @@ const signalingClient = (localStream: MediaStream, webRTCMap: Map<string, WebRTC
     peerConnection.onicecandidate = ({ candidate }) => {
       if (candidate) {
         socket.emit('sendIceCandidate', { targetId: newId, iceCandidate: candidate });
-      }
-    };
-
-    peerConnection.onconnectionstatechange = () => {
-      if (isDisconnected(peerConnection)) {
-        handlePeerDisconnection(peerConnection, newId);
       }
     };
 

--- a/client/src/socket/signalingClient.ts
+++ b/client/src/socket/signalingClient.ts
@@ -3,15 +3,6 @@ import { io } from 'socket.io-client';
 const configuration = {
   iceServers: [
     {
-      urls: [
-        'stun:stun.l.google.com:19302',
-        'stun:stun1.l.google.com:19302',
-        'stun:stun2.l.google.com:19302',
-        'stun:stun3.l.google.com:19302',
-        'stun:stun4.l.google.com:19302',
-      ],
-    },
-    {
       urls: import.meta.env.VITE_TURN_SERVER_URL,
       username: import.meta.env.VITE_TURN_SERVER_USERNAME,
       credential: import.meta.env.VITE_TURN_SERVER_CREDENTIAL,


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #166 

## 소요 시간

6시간

## 개발한 사항

- 처음 공부방에 접속 시 카메라가 켜지지 않고 오디오만 연결되도록 수정
- 카메라 토글 버튼을 누르면 카메라 자체가 온/오프되고 맞춰서 비디오 전송이 온/오프되도록 개선

## 고민했던 사항

- `peerConnection`에 비디오 트랙을 추가/제거 시 재협상(SDP 재교환) 방법
- 별도의 소켓 이벤트를 추가하지 않고 기존 Signaling 과정을 이용하여 재협상
  - `negotiationneeded` 이벤트 추가
  - `answerRequest` 이벤트에서는 재협상 과정인지 확인하여 작동
- 비디오 트랙을 제거한 경우에는 상대방 화면에서 리렌더링되지 않는 문제
  - `track.stop()`을 한 경우에는 track에 `ended` 이벤트가 발생하지 않는 문제

## 참조 (생략 가능)

- https://developer.mozilla.org/en-US/docs/Web/API/MediaStreamTrack/ended_event
- https://stackoverflow.com/questions/55953038/why-is-the-ended-event-not-firing-for-this-mediastreamtrack
