### PR TITLE
<BE> Repository의 메소드명 수정

### DIFF
--- a/server/src/study-room/repository/study-room-participant.repository.spec.ts
+++ b/server/src/study-room/repository/study-room-participant.repository.spec.ts
@@ -48,7 +48,7 @@ describe('Study Room Participant 레포지토리 테스트', () => {
       const roomId = 1;
       const socketId = '12345';
 
-      await studyRoomParticipantRepository.addUserToRoom(roomId, socketId);
+      await studyRoomParticipantRepository.saveParticipant(roomId, socketId);
 
       const savedParticipant = await repository.findOne({
         where: { socket_id: socketId, room_id: roomId },
@@ -65,9 +65,9 @@ describe('Study Room Participant 레포지토리 테스트', () => {
       const roomId = 1;
       const socketId = '12345';
 
-      await studyRoomParticipantRepository.addUserToRoom(roomId, socketId);
+      await studyRoomParticipantRepository.saveParticipant(roomId, socketId);
 
-      const result = await studyRoomParticipantRepository.findParticipant(socketId);
+      const result = await studyRoomParticipantRepository.findParticipantBySocketId(socketId);
 
       expect(result).toBeDefined();
       expect(result?.socket_id).toEqual(socketId);
@@ -77,7 +77,7 @@ describe('Study Room Participant 레포지토리 테스트', () => {
     it('사용자가 존재하지 않으면 null을 반환한다.', async () => {
       const socketId = '99999';
 
-      const result = await studyRoomParticipantRepository.findParticipant(socketId);
+      const result = await studyRoomParticipantRepository.findParticipantBySocketId(socketId);
 
       expect(result).toBeNull();
     });
@@ -88,9 +88,9 @@ describe('Study Room Participant 레포지토리 테스트', () => {
       const roomId = 1;
       const socketId = '12345';
 
-      await studyRoomParticipantRepository.addUserToRoom(roomId, socketId);
+      await studyRoomParticipantRepository.saveParticipant(roomId, socketId);
 
-      await studyRoomParticipantRepository.removeUserFromRoom(roomId, socketId);
+      await studyRoomParticipantRepository.deleteParticipantBySocketId(roomId, socketId);
 
       const result = await repository.findOne({
         where: { socket_id: socketId, room_id: roomId },
@@ -104,7 +104,7 @@ describe('Study Room Participant 레포지토리 테스트', () => {
       const socketId = '99999';
 
       await expect(
-        studyRoomParticipantRepository.removeUserFromRoom(roomId, socketId),
+        studyRoomParticipantRepository.deleteParticipantBySocketId(roomId, socketId),
       ).rejects.toThrow('Participant not found in the room');
     });
   });
@@ -118,13 +118,13 @@ describe('Study Room Participant 레포지토리 테스트', () => {
       ];
 
       for (const participant of participants) {
-        await studyRoomParticipantRepository.addUserToRoom(
+        await studyRoomParticipantRepository.saveParticipant(
           participant.roomId,
           participant.socketId,
         );
       }
 
-      const result = await studyRoomParticipantRepository.getRoomUsers(roomId);
+      const result = await studyRoomParticipantRepository.findParticipantsByRoomId(roomId);
 
       expect(result).toEqual([{ socketId: '12345' }, { socketId: '67890' }]);
     });

--- a/server/src/study-room/repository/study-room.repository.spec.ts
+++ b/server/src/study-room/repository/study-room.repository.spec.ts
@@ -46,7 +46,7 @@ describe('Study Room 레포지토리 테스트', () => {
       const categoryName = '1';
 
       // 방 생성
-      const result = await studyRoomRepository.createRoom(roomName, password, categoryName);
+      const result = await studyRoomRepository.saveRoom(roomName, password, categoryName);
 
       // 검증
       expect(result).toBeDefined();
@@ -70,10 +70,10 @@ describe('Study Room 레포지토리 테스트', () => {
       const categoryName = '1';
 
       // 생성된 방 추가
-      const expectedRoom = await studyRoomRepository.createRoom(roomName, password, categoryName);
+      const expectedRoom = await studyRoomRepository.saveRoom(roomName, password, categoryName);
 
       // 실행
-      const result = await studyRoomRepository.findRoom(expectedRoom.room_id);
+      const result = await studyRoomRepository.findRoomById(expectedRoom.room_id);
 
       // 검증
       expect(result).toBeDefined();
@@ -86,7 +86,7 @@ describe('Study Room 레포지토리 테스트', () => {
       const roomId = 999;
 
       // 실행
-      const result = await studyRoomRepository.findRoom(roomId);
+      const result = await studyRoomRepository.findRoomById(roomId);
 
       // 검증
       expect(result).toBeNull();

--- a/server/src/study-room/repository/study-room.repository.ts
+++ b/server/src/study-room/repository/study-room.repository.ts
@@ -10,8 +10,7 @@ export class StudyRoomRepository {
     private readonly repository: Repository<StudyRoom>,
   ) {}
 
-  // 방 생성
-  async createRoom(roomName: string, password: string, categoryName: string): Promise<StudyRoom> {
+  async saveRoom(roomName: string, password: string, categoryName: string): Promise<StudyRoom> {
     const newRoom = this.repository.create({
       room_name: roomName,
       password: password,
@@ -21,13 +20,11 @@ export class StudyRoomRepository {
     return await this.repository.save(newRoom);
   }
 
-  // 방 조회
-  async getRooms(): Promise<StudyRoom[]> {
+  async findAllRooms(): Promise<StudyRoom[]> {
     return this.repository.find();
   }
 
-  // 특정 방 조회
-  findRoom(roomId: number): Promise<StudyRoom | null> {
+  findRoomById(roomId: number): Promise<StudyRoom | null> {
     return this.repository.findOne({ where: { room_id: roomId } });
   }
 }

--- a/server/src/study-room/study-room.service.ts
+++ b/server/src/study-room/study-room.service.ts
@@ -23,11 +23,9 @@ export class StudyRoomsService {
    * @param categoryName 방 카테고리 명
    * @returns 생성된 방
    */
-  // TODO 생성된 방 entity를 그대로 주는 것보다 방 생성 성공 여부를 가르는 것은 어떤가요.
-  // TODO 나중에는 카테고리 ID도 필요해요.
   async createRoom(createRoomRequestDto: CreateRoomRequestDto): Promise<CreateRoomResponseDto> {
     const { roomName, password, categoryName } = createRoomRequestDto;
-    const studyRoom = await this.roomRepository.createRoom(roomName, password, categoryName);
+    const studyRoom = await this.roomRepository.saveRoom(roomName, password, categoryName);
     const response = new CreateRoomResponseDto(studyRoom.room_id);
     return response;
   }
@@ -38,7 +36,7 @@ export class StudyRoomsService {
    * @returns 방 객체 또는 undefined
    */
   async findRoom(roomId: string): Promise<StudyRoom | null> {
-    const room = await this.roomRepository.findRoom(parseInt(roomId, 10));
+    const room = await this.roomRepository.findRoomById(parseInt(roomId, 10));
     return room || undefined; // null 대신 undefined로 반환
   }
 
@@ -96,7 +94,7 @@ export class StudyRoomsService {
    * 존재하는 모든 방을 조회합니다.
    */
   async getAllRoom(): Promise<RoomInfoResponseDto[]> {
-    const roomList = await this.roomRepository.getRooms();
+    const roomList = await this.roomRepository.findAllRooms();
 
     const roomInfoResponseDtoList = [];
     for (const roomInfo of roomList) {
@@ -117,9 +115,9 @@ export class StudyRoomsService {
   }
 
   private async isValidRoom(roomId: string): Promise<void> {
-    const room = await this.roomRepository.findRoom(parseInt(roomId, 10));
+    const room = await this.roomRepository.findRoomById(parseInt(roomId, 10));
     if (!room) {
-      this.roomRepository.createRoom('테스트용 방', null, '#test');
+      this.roomRepository.saveRoom('테스트용 방', null, '#test');
       // throw new Error('Room not found');
     }
   }
@@ -138,7 +136,7 @@ export class StudyRoomsService {
    */
   async checkAccess(checkAccessRequestDto: CheckAccessRequestDto) {
     const { password, roomId } = checkAccessRequestDto;
-    const studyRoom = await this.roomRepository.findRoom(roomId);
+    const studyRoom = await this.roomRepository.findRoomById(roomId);
     if (!studyRoom) {
       throw new NotFoundException('No such study room');
     }


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #175 

## 소요 시간

## 개발한 사항
### study-room
`createRoom` -> `saveRoom`
`getRooms` -> `findAllRooms`
`findRoom` -> `findRoomById`

### study-room-participant
`addUserToRoom` -> `saveParticipant` 
`findParticipant` -> `findParticipantBySocketId`
`getRoomUsers` -> `findParticipantsByRoomId` 
`findRoomIdBySocketId` -> 추가
`removeUserFromRoom` -> `deleteParticipantBySocketId`
`leaveAllRooms` -> 삭제
`getAllRooms` -> 삭제

## 고민했던 사항

4가지 기준을 세웠습니다.
- 동사를 CRUD에 맞게 하였는가?
  - CREATE : add
  - READ : find
  - UPDATE : update
  - DELETE : delete
- 조건 추가 시 by로 조건을 추가하였는가?
  - 예시 : roomId로 room을 찾는다면 -> findRoomById
- 복수 데이터는 복수형으로 반환하였는가?
- 서비스 로직의 메소드의 반환값은 전혀 건드리지 않았는가?

## 참조 (생략 가능)

