### PR TITLE
<FE> 상대방 비디오와 스톱워치가 동시에 활성화된 경우 발생하는 영상 깜빡임 문제 해결

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import { createBrowserRouter, RouterProvider, Navigate } from 'react-router-dom';
 import ProtectedRoute from '@components/common/ProtectedRoute';
 import Home from '@components/Home/Home';
 import StudyRoomList from '@components/StudyRoomList/index';
@@ -24,6 +24,7 @@ const router = createBrowserRouter([
         <StudyRoom />
       </ProtectedRoute>
     ),
+    errorElement: <Navigate to="/studyroomlist" replace />,
   },
 ]);
 

--- a/client/src/components/StudyRoom/StudyRoom.tsx
+++ b/client/src/components/StudyRoom/StudyRoom.tsx
@@ -22,7 +22,7 @@ const StudyRoom = () => {
   const [newMessage, setNewMessage] = useState('');
 
   const [
-    { localVideoRef, webRTCMap, participantCount, grid },
+    { localStream, webRTCMap, participantCount, grid },
     { toggleVideo, toggleMic, joinRoom, exitRoom, sendMessage },
   ] = useWebRTC();
 
@@ -49,7 +49,7 @@ const StudyRoom = () => {
           webRTCMap={webRTCMap}
         />
         <VideoGrid
-          localVideoRef={localVideoRef}
+          localStream={localStream}
           webRTCMap={webRTCMap}
           participantCount={participantCount}
           grid={grid}

--- a/client/src/components/StudyRoom/Video.tsx
+++ b/client/src/components/StudyRoom/Video.tsx
@@ -1,0 +1,46 @@
+import { useEffect, useRef } from 'react';
+
+interface VideoProps {
+  mediaStream: MediaStream;
+  dataChannel?: RTCDataChannel;
+  nickName: string;
+  gridCols: number;
+  muted: boolean;
+}
+
+const Video = ({ mediaStream, muted }: VideoProps) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (!mediaStream.active) return;
+
+    const handleTrackEvent = () => {
+      if (videoRef.current) {
+        videoRef.current.srcObject = mediaStream;
+      }
+    };
+
+    handleTrackEvent();
+    mediaStream.addEventListener('addtrack', handleTrackEvent);
+    mediaStream.addEventListener('removetrack', handleTrackEvent);
+
+    return () => {
+      mediaStream.removeEventListener('addtrack', handleTrackEvent);
+      mediaStream.removeEventListener('removetrack', handleTrackEvent);
+    };
+  }, [mediaStream]);
+
+  return (
+    <video
+      className="rounded-2xl"
+      width="100%"
+      height="100%"
+      ref={videoRef}
+      autoPlay
+      playsInline
+      muted={muted}
+    />
+  );
+};
+
+export default Video;

--- a/client/src/components/StudyRoom/VideoGrid.tsx
+++ b/client/src/components/StudyRoom/VideoGrid.tsx
@@ -25,6 +25,86 @@ interface VideoGridProps {
   grid: Grid;
 }
 
+const RemoteVideo = ({
+  remoteStream,
+  nickName,
+  elapsedSeconds,
+  gridCols,
+}: {
+  remoteStream: MediaStream;
+  nickName: string;
+  elapsedSeconds: number;
+  gridCols: number;
+}) => {
+  const videoRef = useRef<HTMLVideoElement>(null);
+
+  useEffect(() => {
+    if (videoRef.current) {
+      videoRef.current.srcObject = remoteStream;
+    }
+
+    const handleTrackEvent = () => {
+      if (videoRef.current) {
+        videoRef.current.srcObject = remoteStream;
+      }
+    };
+
+    remoteStream.addEventListener('addtrack', handleTrackEvent);
+    remoteStream.addEventListener('removetrack', handleTrackEvent);
+
+    return () => {
+      remoteStream.removeEventListener('addtrack', handleTrackEvent);
+      remoteStream.removeEventListener('removetrack', handleTrackEvent);
+    };
+  }, [remoteStream]);
+
+  return (
+    <div
+      className="relative rounded-2xl bg-black"
+      style={{
+        height: `${MAX_HEIGHT / gridCols}px`,
+        width: `${MAX_WIDTH / gridCols}px`,
+      }}
+    >
+      <video
+        className="rounded-2xl"
+        width="100%"
+        height="100%"
+        ref={videoRef}
+        autoPlay
+        playsInline
+        muted={false}
+      />
+      <div
+        className="bg-gomz-black absolute left-0 top-full flex w-full items-center justify-between rounded-b-2xl text-white opacity-85"
+        style={{
+          height: `${Math.max(5 / Math.sqrt(gridCols), 2)}rem`,
+          transform: `translateY(-${Math.max(5 / Math.sqrt(gridCols), 2)}rem)`,
+          padding: `0 ${Math.max(3 / Math.sqrt(gridCols), 1)}rem`,
+        }}
+      >
+        <div
+          className="truncate font-normal"
+          style={{
+            fontSize: `${Math.max(1.75 / Math.sqrt(gridCols), 0.625)}rem`,
+            maxWidth: `${MAX_WIDTH / gridCols / 2.5}px`,
+          }}
+        >
+          {nickName}
+        </div>
+        <div
+          className="truncate font-normal"
+          style={{
+            fontSize: `${Math.max(1.75 / Math.sqrt(gridCols), 0.625)}rem`,
+          }}
+        >
+          <StopWatch elapsedSeconds={elapsedSeconds} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
 const VideoGrid = ({ localVideoRef, webRTCMap, participantCount, grid }: VideoGridProps) => {
   const elapsedSecondsMap = useRef(new Map<string, number>());
   const [, forceUpdate] = useState(0);
@@ -88,55 +168,14 @@ const VideoGrid = ({ localVideoRef, webRTCMap, participantCount, grid }: VideoGr
           </div>
         </div>
       </div>
-      {[...webRTCMap.current].map(([id, { remoteStream }]) => (
-        <div
-          key={String(id)}
-          className="relative rounded-2xl bg-black"
-          style={{
-            height: `${MAX_HEIGHT / grid.cols}px`,
-            width: `${MAX_WIDTH / grid.cols}px`,
-          }}
-        >
-          <video
-            className="rounded-2xl"
-            width="100%"
-            height="100%"
-            ref={(element) => {
-              if (element) {
-                element.srcObject = remoteStream;
-              }
-            }}
-            autoPlay
-            playsInline
-            muted={false}
-          />
-          <div
-            className="bg-gomz-black absolute left-0 top-full flex w-full items-center justify-between rounded-b-2xl text-white opacity-85"
-            style={{
-              height: `${Math.max(5 / Math.sqrt(grid.cols), 2)}rem`,
-              transform: `translateY(-${Math.max(5 / Math.sqrt(grid.cols), 2)}rem)`,
-              padding: `0 ${Math.max(3 / Math.sqrt(grid.cols), 1)}rem`,
-            }}
-          >
-            <div
-              className="truncate font-normal"
-              style={{
-                fontSize: `${Math.max(1.75 / Math.sqrt(grid.cols), 0.625)}rem`,
-                maxWidth: `${MAX_WIDTH / grid.cols / 2.5}px`,
-              }}
-            >
-              {webRTCMap.current.get(id)!.nickName}
-            </div>
-            <div
-              className="truncate font-normal"
-              style={{
-                fontSize: `${Math.max(1.75 / Math.sqrt(grid.cols), 0.625)}rem`,
-              }}
-            >
-              <StopWatch elapsedSeconds={elapsedSecondsMap.current.get(id)!} />
-            </div>
-          </div>
-        </div>
+      {[...webRTCMap.current].map(([id, { remoteStream, nickName }]) => (
+        <RemoteVideo
+          key={id}
+          remoteStream={remoteStream}
+          nickName={nickName}
+          elapsedSeconds={elapsedSecondsMap.current.get(id)!}
+          gridCols={grid.cols}
+        />
       ))}
     </section>
   );

--- a/client/src/components/StudyRoom/VideoGrid.tsx
+++ b/client/src/components/StudyRoom/VideoGrid.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, useRef } from 'react';
-import StopWatch from '@components/common/StopWatch';
+import Video from '@components/StudyRoom/Video';
+import VideoOverlay from '@components/StudyRoom/VideoOverlay';
 
 const RATIO = 4 / 3;
 const MAX_HEIGHT = 600;
@@ -19,113 +19,13 @@ interface WebRTCData {
 }
 
 interface VideoGridProps {
-  localVideoRef: React.RefObject<HTMLVideoElement>;
+  localStream: MediaStream;
   webRTCMap: React.MutableRefObject<Map<string, WebRTCData>>;
   participantCount: number;
   grid: Grid;
 }
 
-const RemoteVideo = ({
-  remoteStream,
-  nickName,
-  elapsedSeconds,
-  gridCols,
-}: {
-  remoteStream: MediaStream;
-  nickName: string;
-  elapsedSeconds: number;
-  gridCols: number;
-}) => {
-  const videoRef = useRef<HTMLVideoElement>(null);
-
-  useEffect(() => {
-    if (videoRef.current) {
-      videoRef.current.srcObject = remoteStream;
-    }
-
-    const handleTrackEvent = () => {
-      if (videoRef.current) {
-        videoRef.current.srcObject = remoteStream;
-      }
-    };
-
-    remoteStream.addEventListener('addtrack', handleTrackEvent);
-    remoteStream.addEventListener('removetrack', handleTrackEvent);
-
-    return () => {
-      remoteStream.removeEventListener('addtrack', handleTrackEvent);
-      remoteStream.removeEventListener('removetrack', handleTrackEvent);
-    };
-  }, [remoteStream]);
-
-  return (
-    <div
-      className="relative rounded-2xl bg-black"
-      style={{
-        height: `${MAX_HEIGHT / gridCols}px`,
-        width: `${MAX_WIDTH / gridCols}px`,
-      }}
-    >
-      <video
-        className="rounded-2xl"
-        width="100%"
-        height="100%"
-        ref={videoRef}
-        autoPlay
-        playsInline
-        muted={false}
-      />
-      <div
-        className="bg-gomz-black absolute left-0 top-full flex w-full items-center justify-between rounded-b-2xl text-white opacity-85"
-        style={{
-          height: `${Math.max(5 / Math.sqrt(gridCols), 2)}rem`,
-          transform: `translateY(-${Math.max(5 / Math.sqrt(gridCols), 2)}rem)`,
-          padding: `0 ${Math.max(3 / Math.sqrt(gridCols), 1)}rem`,
-        }}
-      >
-        <div
-          className="truncate font-normal"
-          style={{
-            fontSize: `${Math.max(1.75 / Math.sqrt(gridCols), 0.625)}rem`,
-            maxWidth: `${MAX_WIDTH / gridCols / 2.5}px`,
-          }}
-        >
-          {nickName}
-        </div>
-        <div
-          className="truncate font-normal"
-          style={{
-            fontSize: `${Math.max(1.75 / Math.sqrt(gridCols), 0.625)}rem`,
-          }}
-        >
-          <StopWatch elapsedSeconds={elapsedSeconds} />
-        </div>
-      </div>
-    </div>
-  );
-};
-
-const VideoGrid = ({ localVideoRef, webRTCMap, participantCount, grid }: VideoGridProps) => {
-  const elapsedSecondsMap = useRef(new Map<string, number>());
-  const [, forceUpdate] = useState(0);
-
-  useEffect(() => {
-    webRTCMap.current.forEach(({ dataChannel }, id) => {
-      dataChannel.onmessage = ({ data }) => {
-        const elapsedSeconds = Number(data);
-        elapsedSecondsMap.current.set(id, elapsedSeconds);
-        forceUpdate(elapsedSeconds);
-      };
-    });
-
-    return () => {
-      webRTCMap.current.forEach(({ dataChannel }, id) => {
-        elapsedSecondsMap.current.delete(id);
-        dataChannel.onmessage = () => {};
-      });
-    };
-  }, [participantCount]);
-
+const VideoGrid = ({ localStream, webRTCMap, grid }: VideoGridProps) => {
   return (
     <section
       className="flex flex-wrap items-center justify-center"
@@ -142,40 +42,32 @@ const VideoGrid = ({ localVideoRef, webRTCMap, participantCount, grid }: VideoGr
           width: `${MAX_WIDTH / grid.cols}px`,
         }}
       >
-        <video
-          className="h-full w-full rounded-2xl"
-          ref={localVideoRef}
-          autoPlay
-          playsInline
-          muted
+        <Video
+          mediaStream={localStream}
+          nickName={localStorage.getItem('nickName')!}
+          gridCols={grid.cols}
+          muted={true}
         />
+        <VideoOverlay nickName={localStorage.getItem('nickName')!} gridCols={grid.cols} />
+      </div>
+      {[...webRTCMap.current].map(([id, { remoteStream, dataChannel, nickName }]) => (
         <div
-          className="bg-gomz-black absolute left-0 top-full flex w-full items-center justify-between rounded-b-2xl text-white opacity-85"
+          className="relative rounded-2xl bg-black"
           style={{
-            height: `${Math.max(5 / Math.sqrt(grid.cols), 2)}rem`,
-            transform: `translateY(-${Math.max(5 / Math.sqrt(grid.cols), 2)}rem)`,
-            padding: `0 ${Math.max(3 / Math.sqrt(grid.cols), 1)}rem`,
+            height: `${MAX_HEIGHT / grid.cols}px`,
+            width: `${MAX_WIDTH / grid.cols}px`,
           }}
         >
-          <div
-            className="truncate font-normal"
-            style={{
-              fontSize: `${Math.max(1.75 / Math.sqrt(grid.cols), 0.625)}rem`,
-              maxWidth: `${MAX_WIDTH / grid.cols / 2.5}px`,
-            }}
-          >
-            {localStorage.getItem('nickName')}
-          </div>
+          <Video
+            key={id}
+            mediaStream={remoteStream}
+            dataChannel={dataChannel}
+            nickName={nickName}
+            gridCols={grid.cols}
+            muted={false}
+          />
+          <VideoOverlay nickName={nickName} dataChannel={dataChannel} gridCols={grid.cols} />
         </div>
-      </div>
-      {[...webRTCMap.current].map(([id, { remoteStream, nickName }]) => (
-        <RemoteVideo
-          key={id}
-          remoteStream={remoteStream}
-          nickName={nickName}
-          elapsedSeconds={elapsedSecondsMap.current.get(id)!}
-          gridCols={grid.cols}
-        />
       ))}
     </section>
   );

--- a/client/src/components/StudyRoom/VideoOverlay.tsx
+++ b/client/src/components/StudyRoom/VideoOverlay.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import StopWatch from '@components/common/StopWatch';
+
+const RATIO = 4 / 3;
+const MAX_HEIGHT = 600;
+const MAX_WIDTH = MAX_HEIGHT * RATIO;
+
+interface VideoOverlayProps {
+  nickName: string;
+  dataChannel?: RTCDataChannel;
+  gridCols: number;
+}
+
+const VideoOverlay = ({ nickName, dataChannel, gridCols }: VideoOverlayProps) => {
+  const [elapsedSeconds, setElapsedSeconds] = useState(0);
+
+  useEffect(() => {
+    if (!dataChannel) return;
+
+    const handleMessage = ({ data }: { data: string }) => {
+      setElapsedSeconds(Number(data));
+    };
+
+    dataChannel.addEventListener('message', handleMessage);
+
+    return () => {
+      if (!dataChannel) return;
+      dataChannel.removeEventListener('message', handleMessage);
+    };
+  }, []);
+
+  return (
+    <div
+      className="bg-gomz-black absolute left-0 top-full flex w-full items-center justify-between truncate rounded-b-2xl font-normal text-white opacity-85"
+      style={{
+        height: `${Math.max(5 / Math.sqrt(gridCols), 2)}rem`,
+        transform: `translateY(-${Math.max(5 / Math.sqrt(gridCols), 2)}rem)`,
+        padding: `0 ${Math.max(3 / Math.sqrt(gridCols), 1)}rem`,
+      }}
+    >
+      <div
+        style={{
+          fontSize: `${Math.max(1.75 / Math.sqrt(gridCols), 0.625)}rem`,
+          maxWidth: `${MAX_WIDTH / gridCols / 2.5}px`,
+        }}
+      >
+        {nickName}
+      </div>
+      <div
+        style={{
+          fontSize: `${Math.max(1.75 / Math.sqrt(gridCols), 0.625)}rem`,
+        }}
+      >
+        {dataChannel && <StopWatch elapsedSeconds={elapsedSeconds} />}
+      </div>
+    </div>
+  );
+};
+
+export default VideoOverlay;


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #177 

## 소요 시간

4시간

## 개발한 사항

- 상대방 비디오와 스톱워치가 동시에 활성화된 경우 발생하는 영상 깜빡임 문제 해결
- VideoGrid 컴포넌트에서 Video & VideoOverlay 컴포넌트 분리
- 공부방 페이지에서 에러 발생 시 공부방 리스트 페이지로 이동하도록 수정

![Nov-26-2024 09-42-24](https://github.com/user-attachments/assets/9f064422-2dcd-4770-9911-afad5d1de568)

## 고민했던 사항

- [스톱워치 활성화 시 영상 깜빡임 문제](https://www.notion.so/14afab6ff8a7808ca02cfaec588ba876?pvs=4)
