### PR TITLE
<FE> 카메라⋅마이크 전환 기능 구현

### DIFF
--- a/client/src/components/StudyRoom/ControlBar.tsx
+++ b/client/src/components/StudyRoom/ControlBar.tsx
@@ -9,6 +9,8 @@ interface ControlBarProps {
   toggleChat: () => void;
   exitRoom: () => void;
   isChatOn: boolean;
+  getVideoDevices: () => Promise<MediaDeviceInfo[]>;
+  getAudioDevices: () => Promise<MediaDeviceInfo[]>;
 }
 
 const ControlBar = ({
@@ -18,36 +20,44 @@ const ControlBar = ({
   toggleChat,
   exitRoom,
   isChatOn,
+  getVideoDevices,
+  getAudioDevices,
 }: ControlBarProps) => {
   const [isVideoOn, setIsVideoOn] = useState(false);
   const [isMicOn, setIsMicOn] = useState(false);
+  const [isVideoSelectModalOpen, setIsVideoSelectModalOpen] = useState(false);
+  const [isAudioSelectModalOpen, setIsAudioSelectModalOpen] = useState(false);
 
   return (
     <div className={`relative flex gap-10 ${className}`}>
-      {/* <MediaSelectModal className="absolute -left-28 bottom-14" /> */}
-      <MediaSelectModal className="absolute bottom-14 left-0" />
       <div className="bg-gomz-gray-300 flex h-10 w-20 items-center rounded-full">
         <button
-          onClick={() => toggleVideo().then((result) => setIsVideoOn(result))}
           className="bg-gomz-black flex h-10 w-12 items-center justify-center rounded-full"
+          onClick={() => toggleVideo().then((result) => setIsVideoOn(result))}
         >
           <Icon
             id={isVideoOn ? 'video' : 'video-off'}
             className="text-gomz-white h-5 w-5 fill-current"
           />
         </button>
-        <button className="flex h-10 w-6 items-center justify-center rounded-full">
+        <button
+          className="flex h-10 w-6 items-center justify-center rounded-full"
+          onClick={() => setIsVideoSelectModalOpen(!isVideoSelectModalOpen)}
+        >
           <Icon id="chevron" className="h-5 w-5 rotate-90" />
         </button>
       </div>
       <div className="bg-gomz-gray-300 flex h-10 w-20 items-center rounded-full">
         <button
-          onClick={() => setIsMicOn(toggleMic())}
           className="bg-gomz-black flex h-10 w-12 items-center justify-center rounded-full"
+          onClick={() => setIsMicOn(toggleMic())}
         >
           <Icon id={isMicOn ? 'mic' : 'mic-off'} className="text-gomz-white h-6 w-6 fill-current" />
         </button>
-        <button className="flex h-10 w-6 items-center justify-center rounded-full">
+        <button
+          className="flex h-10 w-6 items-center justify-center rounded-full"
+          onClick={() => setIsAudioSelectModalOpen(!isAudioSelectModalOpen)}
+        >
           <Icon id="chevron" className="h-5 w-5 rotate-90" />
         </button>
       </div>
@@ -71,6 +81,18 @@ const ControlBar = ({
       >
         <Icon id="call-end" className="text-gomz-white h-7 w-7 fill-current" />
       </button>
+      {isVideoSelectModalOpen && (
+        <MediaSelectModal
+          className="absolute bottom-0 -translate-y-14 translate-x-10"
+          getMediaDevices={getVideoDevices}
+        />
+      )}
+      {isAudioSelectModalOpen && (
+        <MediaSelectModal
+          className="absolute bottom-0 -translate-y-14 translate-x-40"
+          getMediaDevices={getAudioDevices}
+        />
+      )}
     </div>
   );
 };

--- a/client/src/components/StudyRoom/ControlBar.tsx
+++ b/client/src/components/StudyRoom/ControlBar.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { SetStateAction, useState } from 'react';
 import Icon from '@components/common/Icon';
 import MediaSelectModal from '@components/StudyRoom/MediaSelectModal';
 
@@ -11,6 +11,10 @@ interface ControlBarProps {
   isChatOn: boolean;
   getVideoDevices: () => Promise<MediaDeviceInfo[]>;
   getAudioDevices: () => Promise<MediaDeviceInfo[]>;
+  selectedVideoDeviceId: string;
+  selectedAudioDeviceId: string;
+  setSelectedVideoDeviceId: React.Dispatch<SetStateAction<string>>;
+  setSelectedAudioDeviceId: React.Dispatch<SetStateAction<string>>;
 }
 
 const ControlBar = ({
@@ -22,6 +26,10 @@ const ControlBar = ({
   isChatOn,
   getVideoDevices,
   getAudioDevices,
+  selectedVideoDeviceId,
+  selectedAudioDeviceId,
+  setSelectedVideoDeviceId,
+  setSelectedAudioDeviceId,
 }: ControlBarProps) => {
   const [isVideoOn, setIsVideoOn] = useState(false);
   const [isMicOn, setIsMicOn] = useState(false);
@@ -84,12 +92,16 @@ const ControlBar = ({
       {isVideoSelectModalOpen && (
         <MediaSelectModal
           className="absolute bottom-0 -translate-y-14 translate-x-10"
+          selectedMediaDeviceId={selectedVideoDeviceId}
+          setSelectedMediaDevice={setSelectedVideoDeviceId}
           getMediaDevices={getVideoDevices}
         />
       )}
       {isAudioSelectModalOpen && (
         <MediaSelectModal
           className="absolute bottom-0 -translate-y-14 translate-x-40"
+          selectedMediaDeviceId={selectedAudioDeviceId}
+          setSelectedMediaDevice={setSelectedAudioDeviceId}
           getMediaDevices={getAudioDevices}
         />
       )}

--- a/client/src/components/StudyRoom/MediaSelectModal.tsx
+++ b/client/src/components/StudyRoom/MediaSelectModal.tsx
@@ -1,23 +1,25 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, SetStateAction } from 'react';
 import Icon from '@components/common/Icon';
 
 interface MediaSelectModalProps {
   className?: string;
+  selectedMediaDeviceId: string;
+  setSelectedMediaDevice: React.Dispatch<SetStateAction<string>>;
   getMediaDevices: () => Promise<MediaDeviceInfo[]>;
 }
 
-const MediaSelectModal = ({ className, getMediaDevices }: MediaSelectModalProps) => {
+const MediaSelectModal = ({
+  className,
+  selectedMediaDeviceId,
+  setSelectedMediaDevice,
+  getMediaDevices,
+}: MediaSelectModalProps) => {
   const [mediaDevices, setMediaDevices] = useState<MediaDeviceInfo[]>([]);
-  const [selectedDeviceId, setSelectedDeviceId] = useState('default');
 
   useEffect(() => {
     const init = async () => {
       const devices = await getMediaDevices();
       setMediaDevices(devices);
-
-      if (devices.every(({ deviceId }) => deviceId !== 'default')) {
-        setSelectedDeviceId(devices[0].deviceId);
-      }
     };
 
     init();
@@ -29,12 +31,17 @@ const MediaSelectModal = ({ className, getMediaDevices }: MediaSelectModalProps)
     >
       {mediaDevices.map((device) => (
         <div className="flex gap-3">
-          {selectedDeviceId === device.deviceId ? (
+          {selectedMediaDeviceId === device.deviceId ? (
             <Icon id="check" className="text-gomz-black my-1 h-6 w-6 fill-current" />
           ) : (
             <div className="my-1 h-6 w-6" />
           )}
-          <button className="truncate py-1" onClick={() => setSelectedDeviceId(device.deviceId)}>
+          <button
+            className="truncate py-1"
+            onClick={() => {
+              setSelectedMediaDevice(device.deviceId);
+            }}
+          >
             {device.label}
           </button>
         </div>

--- a/client/src/components/StudyRoom/MediaSelectModal.tsx
+++ b/client/src/components/StudyRoom/MediaSelectModal.tsx
@@ -1,22 +1,49 @@
+import { useState, useEffect } from 'react';
 import Icon from '@components/common/Icon';
 
-const MediaSelectModal = ({ className }: { className: string }) => {
+interface MediaSelectModalProps {
+  className?: string;
+  getMediaDevices: () => Promise<MediaDeviceInfo[]>;
+}
+
+const MediaSelectModal = ({ className, getMediaDevices }: MediaSelectModalProps) => {
+  const [mediaDevices, setMediaDevices] = useState<MediaDeviceInfo[]>([]);
+  const [selectedDeviceId, setSelectedDeviceId] = useState('default');
+
+  useEffect(() => {
+    const init = async () => {
+      const devices = await getMediaDevices();
+      setMediaDevices(devices);
+
+      if (devices.every(({ deviceId }) => deviceId !== 'default')) {
+        setSelectedDeviceId(devices[0].deviceId);
+      }
+    };
+
+    init();
+  }, []);
+
   return (
     <div
-      className={`bg-gomz-gray-300 flex h-fit w-80 flex-col justify-center gap-2 rounded-2xl border p-3 px-6 opacity-80 shadow-[0.25rem_0.25rem_0.5rem_0_rgba(0,0,0,0.25)] ${className}`}
+      className={`bg-gomz-gray-300 flex h-fit w-fit flex-col justify-center rounded-2xl border p-3 px-6 opacity-80 shadow-[0.25rem_0.25rem_0.5rem_0_rgba(0,0,0,0.25)] ${className}`}
     >
-      <div className="flex gap-3">
-        <Icon id="check" className="text-gomz-black h-6 w-6 fill-current" />
-        <button className="truncate">Camera Option 1</button>
-      </div>
-      <div className="flex gap-3">
-        <Icon id="check" className="text-gomz-black h-6 w-6 fill-current" />
-        <button className="truncate">Camera Option 2</button>
-      </div>
-      <div className="flex gap-3">
-        <Icon id="check" className="text-gomz-black h-6 w-6 fill-current" />
-        <button className="truncate">Camera Option 3</button>
-      </div>
+      {mediaDevices.map((device) => (
+        <div className="flex gap-3">
+          {selectedDeviceId === device.deviceId ? (
+            <Icon id="check" className="text-gomz-black my-1 h-6 w-6 fill-current" />
+          ) : (
+            <div className="my-1 h-6 w-6" />
+          )}
+          <button className="truncate py-1" onClick={() => setSelectedDeviceId(device.deviceId)}>
+            {device.label}
+          </button>
+        </div>
+      ))}
+      {mediaDevices.length === 0 && (
+        <div className="flex justify-center gap-3 px-5 text-lg font-medium">
+          디바이스를 찾을 수 없습니다
+        </div>
+      )}
     </div>
   );
 };

--- a/client/src/components/StudyRoom/StudyRoom.tsx
+++ b/client/src/components/StudyRoom/StudyRoom.tsx
@@ -22,8 +22,25 @@ const StudyRoom = () => {
   const [newMessage, setNewMessage] = useState('');
 
   const [
-    { localStream, webRTCMap, participantCount, grid },
-    { toggleVideo, toggleMic, joinRoom, exitRoom, sendMessage, getVideoDevices, getAudioDevices },
+    {
+      localStream,
+      webRTCMap,
+      participantCount,
+      grid,
+      selectedVideoDeviceId,
+      selectedAudioDeviceId,
+    },
+    {
+      toggleVideo,
+      toggleMic,
+      joinRoom,
+      exitRoom,
+      sendMessage,
+      getVideoDevices,
+      getAudioDevices,
+      setSelectedVideoDeviceId,
+      setSelectedAudioDeviceId,
+    },
   ] = useWebRTC();
 
   useEffect(() => {
@@ -65,6 +82,10 @@ const StudyRoom = () => {
           isChatOn={isChatOn}
           getVideoDevices={getVideoDevices}
           getAudioDevices={getAudioDevices}
+          selectedVideoDeviceId={selectedVideoDeviceId}
+          selectedAudioDeviceId={selectedAudioDeviceId}
+          setSelectedVideoDeviceId={setSelectedVideoDeviceId}
+          setSelectedAudioDeviceId={setSelectedAudioDeviceId}
         />
         {isChatOn && (
           <div

--- a/client/src/components/StudyRoom/StudyRoom.tsx
+++ b/client/src/components/StudyRoom/StudyRoom.tsx
@@ -23,7 +23,7 @@ const StudyRoom = () => {
 
   const [
     { localStream, webRTCMap, participantCount, grid },
-    { toggleVideo, toggleMic, joinRoom, exitRoom, sendMessage },
+    { toggleVideo, toggleMic, joinRoom, exitRoom, sendMessage, getVideoDevices, getAudioDevices },
   ] = useWebRTC();
 
   useEffect(() => {
@@ -63,6 +63,8 @@ const StudyRoom = () => {
           }}
           exitRoom={() => navigate('/study-room-list')}
           isChatOn={isChatOn}
+          getVideoDevices={getVideoDevices}
+          getAudioDevices={getAudioDevices}
         />
         {isChatOn && (
           <div

--- a/client/src/hooks/useWebRTC.ts
+++ b/client/src/hooks/useWebRTC.ts
@@ -22,6 +22,8 @@ interface WebRTCControls {
   joinRoom: (roomId: string) => Promise<Socket>;
   exitRoom: () => void;
   sendMessage: (message: string) => void;
+  getVideoDevices: () => Promise<MediaDeviceInfo[]>;
+  getAudioDevices: () => Promise<MediaDeviceInfo[]>;
 }
 
 const useWebRTC = (): [WebRTCState, WebRTCControls] => {
@@ -120,6 +122,16 @@ const useWebRTC = (): [WebRTCState, WebRTCControls] => {
     socket.current.emit('sendMessage', { message });
   };
 
+  const getVideoDevices = async () => {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    return devices.filter((device) => device.kind === 'videoinput');
+  };
+
+  const getAudioDevices = async () => {
+    const devices = await navigator.mediaDevices.enumerateDevices();
+    return devices.filter((device) => device.kind === 'audioinput');
+  };
+
   return [
     {
       localStream,
@@ -133,6 +145,8 @@ const useWebRTC = (): [WebRTCState, WebRTCControls] => {
       joinRoom,
       exitRoom,
       sendMessage,
+      getVideoDevices,
+      getAudioDevices,
     },
   ];
 };


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #28 

## 소요 시간

2.5

## 개발한 사항

- 카메라⋅마이크 목록 출력 구현
- 카메라⋅마이크 전환 기능 구현

## 고민했던 사항

- default 디바이스가 없는 경우 목록의 첫 번째 디바이스를 선택하도록 했다.
- 사용 가능한 디바이스가 없는 경우 `디바이스가 존재하지 않습니다` 문구를 출력하도록 했다.

## 참조 (생략 가능)

- [브라우저에서 오디오 입출력 제어하기](https://velog.io/@071yoon/%EB%B8%8C%EB%9D%BC%EC%9A%B0%EC%A0%80%EC%97%90%EC%84%9C-%EC%98%A4%EB%94%94%EC%98%A4-%EC%9E%85%EC%B6%9C%EB%A0%A5-%EC%A0%9C%EC%96%B4%ED%95%98%EA%B8%B0)
- [replaceTrack](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/replaceTrack)
