### PR TITLE
<FE> 스톱워치 애니메이션 온 ・ 오프 추가

### DIFF
--- a/client/src/components/StudyRoom/StudyRoomHeader.tsx
+++ b/client/src/components/StudyRoom/StudyRoomHeader.tsx
@@ -49,7 +49,7 @@ const StudyRoomHeader = ({
       }
       stopWatch={
         <div className="flex translate-x-[1.125rem] gap-3 text-xl font-normal">
-          <StopWatch elapsedSeconds={elapsedSeconds} />
+          <StopWatch elapsedSeconds={elapsedSeconds} isAnimationOn={true} />
           <button
             onClick={() => {
               setIsStopWatchRunning(!isStopWatchRunning);

--- a/client/src/components/StudyRoom/VideoOverlay.tsx
+++ b/client/src/components/StudyRoom/VideoOverlay.tsx
@@ -51,7 +51,7 @@ const VideoOverlay = ({ nickName, dataChannel, gridCols }: VideoOverlayProps) =>
           fontSize: `${Math.max(1.75 / Math.sqrt(gridCols), 0.625)}rem`,
         }}
       >
-        {dataChannel && <StopWatch elapsedSeconds={elapsedSeconds} />}
+        {dataChannel && <StopWatch elapsedSeconds={elapsedSeconds} isAnimationOn={false} />}
       </div>
     </div>
   );

--- a/client/src/components/StudyRoomList/Header.tsx
+++ b/client/src/components/StudyRoomList/Header.tsx
@@ -15,7 +15,10 @@ const StudyRoomListHeader = ({ className }: { className?: string }) => {
       }
       stopWatch={
         <div className="text-xl font-normal">
-          <StopWatch elapsedSeconds={Number(localStorage.getItem('totalStudyTime'))} />
+          <StopWatch
+            elapsedSeconds={Number(localStorage.getItem('totalStudyTime'))}
+            isAnimationOn={false}
+          />
         </div>
       }
       userInfo={

--- a/client/src/components/common/StopWatch.tsx
+++ b/client/src/components/common/StopWatch.tsx
@@ -1,79 +1,104 @@
-const StopWatch = ({ elapsedSeconds = 0 }: { elapsedSeconds: number }) => {
+interface StopWatchProps {
+  elapsedSeconds: number;
+  isAnimationOn: boolean;
+}
+
+const secondsToHMS = (elapsedSeconds: number) => {
   const hours = Math.floor(elapsedSeconds / 3600);
   const minutes = Math.floor((elapsedSeconds % 3600) / 60);
   const seconds = elapsedSeconds % 60;
 
+  return { hours, minutes, seconds };
+};
+
+const formatTime = (hours: number, minutes: number, seconds: number) => {
+  const paddedHours = hours.toString().padStart(2, '0');
+  const paddedMinutes = minutes.toString().padStart(2, '0');
+  const paddedSeconds = seconds.toString().padStart(2, '0');
+
+  return `${paddedHours} : ${paddedMinutes} : ${paddedSeconds}`;
+};
+
+const StopWatch = ({ elapsedSeconds = 0, isAnimationOn }: StopWatchProps) => {
+  const { hours, minutes, seconds } = secondsToHMS(elapsedSeconds);
+
   return (
-    <div className="flex items-center gap-2 tabular-nums">
-      <div className="flex">
-        <div className="relative h-[1.75rem] w-[1.0ch] overflow-hidden">
-          <ul
-            className="absolute transition-transform duration-700"
-            style={{ transform: `translateY(-${10 * Math.floor(hours / 10)}%)` }}
-          >
-            {Array.from({ length: 10 }, (_, i) => (
-              <li key={i}>{i}</li>
-            ))}
-          </ul>
+    <>
+      {isAnimationOn ? (
+        <div className="flex items-center gap-2 tabular-nums">
+          <div className="flex">
+            <div className="relative h-[1.75rem] w-[1.0ch] overflow-hidden">
+              <ul
+                className="absolute transition-transform duration-700"
+                style={{ transform: `translateY(-${10 * Math.floor(hours / 10)}%)` }}
+              >
+                {Array.from({ length: 10 }, (_, i) => (
+                  <li key={i}>{i}</li>
+                ))}
+              </ul>
+            </div>
+            <div className="relative h-[1.75rem] w-[1.0ch] overflow-hidden">
+              <ul
+                className="absolute transition-transform duration-700"
+                style={{ transform: `translateY(-${10 * (hours % 10)}%)` }}
+              >
+                {Array.from({ length: 10 }, (_, i) => (
+                  <li key={i}>{i}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+          <span>:</span>
+          <div className="flex">
+            <div className="relative h-[1.75rem] w-[1.0ch] overflow-hidden">
+              <ul
+                className="absolute transition-transform duration-700"
+                style={{ transform: `translateY(-${(100 / 6) * Math.floor(minutes / 10)}%)` }}
+              >
+                {Array.from({ length: 6 }, (_, i) => (
+                  <li key={i}>{i}</li>
+                ))}
+              </ul>
+            </div>
+            <div className="relative h-[1.75rem] w-[1.0ch] overflow-hidden">
+              <ul
+                className="absolute transition-transform duration-700"
+                style={{ transform: `translateY(-${10 * (minutes % 10)}%)` }}
+              >
+                {Array.from({ length: 10 }, (_, i) => (
+                  <li key={i}>{i}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+          <span>:</span>
+          <div className="flex">
+            <div className="relative h-[1.75rem] w-[1.0ch] overflow-hidden">
+              <ul
+                className="absolute transition-transform duration-700"
+                style={{ transform: `translateY(-${(100 / 6) * Math.floor(seconds / 10)}%)` }}
+              >
+                {Array.from({ length: 6 }, (_, i) => (
+                  <li key={i}>{i}</li>
+                ))}
+              </ul>
+            </div>
+            <div className="relative h-[1.75rem] w-[1.0ch] overflow-hidden">
+              <ul
+                className="absolute transition-transform duration-700"
+                style={{ transform: `translateY(-${10 * (seconds % 10)}%)` }}
+              >
+                {Array.from({ length: 10 }, (_, i) => (
+                  <li key={i}>{i}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
         </div>
-        <div className="relative h-[1.75rem] w-[1.0ch] overflow-hidden">
-          <ul
-            className="absolute transition-transform duration-700"
-            style={{ transform: `translateY(-${10 * (hours % 10)}%)` }}
-          >
-            {Array.from({ length: 10 }, (_, i) => (
-              <li key={i}>{i}</li>
-            ))}
-          </ul>
-        </div>
-      </div>
-      <span>:</span>
-      <div className="flex">
-        <div className="relative h-[1.75rem] w-[1.0ch] overflow-hidden">
-          <ul
-            className="absolute transition-transform duration-700"
-            style={{ transform: `translateY(-${(100 / 6) * Math.floor(minutes / 10)}%)` }}
-          >
-            {Array.from({ length: 6 }, (_, i) => (
-              <li key={i}>{i}</li>
-            ))}
-          </ul>
-        </div>
-        <div className="relative h-[1.75rem] w-[1.0ch] overflow-hidden">
-          <ul
-            className="absolute transition-transform duration-700"
-            style={{ transform: `translateY(-${10 * (minutes % 10)}%)` }}
-          >
-            {Array.from({ length: 10 }, (_, i) => (
-              <li key={i}>{i}</li>
-            ))}
-          </ul>
-        </div>
-      </div>
-      <span>:</span>
-      <div className="flex">
-        <div className="relative h-[1.75rem] w-[1.0ch] overflow-hidden">
-          <ul
-            className="absolute transition-transform duration-700"
-            style={{ transform: `translateY(-${(100 / 6) * Math.floor(seconds / 10)}%)` }}
-          >
-            {Array.from({ length: 6 }, (_, i) => (
-              <li key={i}>{i}</li>
-            ))}
-          </ul>
-        </div>
-        <div className="relative h-[1.75rem] w-[1.0ch] overflow-hidden">
-          <ul
-            className="absolute transition-transform duration-700"
-            style={{ transform: `translateY(-${10 * (seconds % 10)}%)` }}
-          >
-            {Array.from({ length: 10 }, (_, i) => (
-              <li key={i}>{i}</li>
-            ))}
-          </ul>
-        </div>
-      </div>
-    </div>
+      ) : (
+        <div className="tabular-nums">{formatTime(hours, minutes, seconds)}</div>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #180 

## 소요 시간

0.5

## 개발한 사항

- 스톱워치 컴포넌트에 애니메이션 온 ・ 오프 추가

## 고민했던 사항

- 디스플레이 해상도에 따라서 상대방 비디오 오버레이에 보이는 스톱워치 애니메이션의 정렬이 어긋날 때가 있다.

<br />

**디스플레이 해상도 (3840 x 2160)**

![Nov-28-2024 10-50-05](https://github.com/user-attachments/assets/99c19afa-c97a-4d00-9bec-14b131e5571b)

<br />

**디스플레이 해상도 (2560 x 1440)**

![Nov-28-2024 10-49-35](https://github.com/user-attachments/assets/d38f33b7-6e6f-45c1-ab85-60398811e5ab)


- 비디오 그리드 계산 시에 비디오 크기, 폰트 크기 등이 계산되는데 1 px보다 작은 단위가 입력되어 어긋나는 것으로 추정
- 비디오 오버레이에서는 스톱워치 애니메이션을 적용하지 않도록 함.
