### PR TITLE
<FE> /socket.io 경로로 지속적으로 HTTP 요청을 보내는 문제 해결

### DIFF
--- a/client/src/hooks/useWebRTC.ts
+++ b/client/src/hooks/useWebRTC.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
-import { io, Socket } from 'socket.io-client';
+import { Socket } from 'socket.io-client';
 import signalingClient from '@socket/signalingClient';
 
 interface WebRTCData {
@@ -33,7 +33,7 @@ interface WebRTCControls {
 const API_BASE_URL = import.meta.env.DEV ? '/api' : import.meta.env.VITE_SIGNALING_SERVER_URL;
 
 const useWebRTC = (): [WebRTCState, WebRTCControls] => {
-  const socket = useRef(io());
+  const socket = useRef<Socket>();
   const webRTCMap = useRef(new Map<string, WebRTCData>());
   const localStreamRef = useRef(new MediaStream());
   const [localStream, setLocalStream] = useState(new MediaStream());
@@ -204,11 +204,11 @@ const useWebRTC = (): [WebRTCState, WebRTCControls] => {
       peerConnection.close();
     });
     localStreamRef.current.getTracks().forEach((track) => track.stop());
-    socket.current.close();
+    socket.current?.close();
   };
 
   const sendMessage = (message: string) => {
-    socket.current.emit('sendMessage', { message });
+    socket.current?.emit('sendMessage', { message });
   };
 
   const getVideoDevices = async () => {

--- a/client/src/socket/signalingClient.ts
+++ b/client/src/socket/signalingClient.ts
@@ -22,7 +22,7 @@ type SignalingClientParams = [Configuration, MediaStream, Map<string, WebRTCData
 const requiredKeys = ['peerConnection', 'remoteStream', 'dataChannel', 'nickName'];
 
 const signalingClient = (...[configuration, localStream, webRTCMap]: SignalingClientParams) => {
-  const socket = io(import.meta.env.VITE_SIGNALING_SERVER_URL);
+  const socket = io(import.meta.env.VITE_SIGNALING_SERVER_URL, { transports: ['websocket'] });
   const pendingConnectionsMap = new Map<string, WebRTCData>();
 
   const updatePendingConnection = (socketId: string, data: Partial<WebRTCData>) => {


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #212 

## 소요 시간

2

## 개발한 사항

- `signalingClient`를 실행하여 소켓을 받아오기 전에 빈 소켓을 생성하지 않도록 수정
- (문제 해결과는 무관함) `signalingClient`에서 소켓을 생성할 때 'transport' 옵션을 명시적으로 'websocket'으로 지정하여 Long polling 방식으로 연결 시도를 하지 않도록 함

![Nov-30-2024 13-21-53](https://github.com/user-attachments/assets/d934a123-1195-40f1-ad1a-3dba01eb9f51)

## 고민했던 사항

- [/socket.io 경로로 지속적으로 HTTP 요청을 보내는 문제](https://www.notion.so/socket-io-HTTP-14efab6ff8a7806db2b7ca9c011c3875?pvs=4)
