### PR TITLE
<BE> 구글 stun 서버 주소 제거

### DIFF
--- a/server/src/study-room/study-room.controller.ts
+++ b/server/src/study-room/study-room.controller.ts
@@ -48,10 +48,8 @@ export class StudyRoomController {
     hmac.end();
     const password = hmac.read();
 
-    const stunUrls = ['stun:stun.l.google.com:19302'];
     return {
       iceServers: [
-        { urls: stunUrls },
         {
           urls: process.env.COTURN_TURN_URL,
           username: username,


### PR DESCRIPTION
## 이슈(수동으로 한 경우 따로 기입)

resolve #239 

## 소요 시간
5분

## 개발한 사항

- webrtc 설정에 구글 stun 서버 제거

## 고민했던 사항

- 개발하며 고민했던 내용 혹은 고민했던 내용을 적은 노션 링크를 적어주세요.

## 참조 (생략 가능)

- 개발 시 참조했던 자료나 링크를 첨부해 주세요.
